### PR TITLE
Creates Symbol primitive

### DIFF
--- a/lib/src/main/kotlin/org/kisu/prefixes/primitives/Representation.kt
+++ b/lib/src/main/kotlin/org/kisu/prefixes/primitives/Representation.kt
@@ -1,0 +1,19 @@
+package org.kisu.prefixes.primitives
+
+/**
+ * A concrete implementation of [Symbol] that represents a unit prefix's symbol as a string.
+ *
+ * This class holds the symbolic representation of a prefix (e.g. `"k"` for kilo, `"m"` for milli) and provides a
+ * standard `toString` implementation that returns the symbol itself.
+ *
+ * @property symbol The string symbol representing the prefix.
+ */
+class Representation(override val symbol: String) : Symbol {
+
+    /**
+     * Returns the symbol string.
+     *
+     * Equivalent to accessing [symbol] directly.
+     */
+    override fun toString(): String = symbol
+}

--- a/lib/src/main/kotlin/org/kisu/prefixes/primitives/Symbol.kt
+++ b/lib/src/main/kotlin/org/kisu/prefixes/primitives/Symbol.kt
@@ -1,0 +1,30 @@
+package org.kisu.prefixes.primitives
+
+/**
+ * Represents the symbolic representation of a unit prefix.
+ *
+ * A `Symbol` is a short textual abbreviation used to denote a prefix in units of measurement. For example:
+ *
+ * - `"k"` for kilo (10³)
+ * - `"M"` for mega (10⁶)
+ * - `"c"` for centi (10⁻²)
+ *
+ * This interface provides access to the symbol string and defines a standard `toString` behavior for consistent display
+ * or serialization.
+ */
+interface Symbol {
+
+    /**
+     * The textual symbol representing this prefix.
+     *
+     * For example: `"k"` for kilo, `"m"` for milli, or `"μ"` for micro.
+     */
+    val symbol: String
+
+    /**
+     * Returns the string representation of the symbol.
+     *
+     * Typically, this should return the same value as [symbol].
+     */
+    override fun toString(): String
+}

--- a/lib/src/test/kotlin/org/kisu/prefixes/primitives/RepresentationTest.kt
+++ b/lib/src/test/kotlin/org/kisu/prefixes/primitives/RepresentationTest.kt
@@ -1,0 +1,18 @@
+package org.kisu.prefixes.primitives
+
+import io.kotest.matchers.shouldBe
+import net.jqwik.api.Arbitraries
+import net.jqwik.api.ForAll
+import net.jqwik.api.Property
+import net.jqwik.api.Provide
+
+class RepresentationTest {
+
+    @Property
+    fun `displays the representation as the symbol`(@ForAll("symbols") symbol: String) {
+        Representation(symbol).toString() shouldBe symbol
+    }
+
+    @Provide
+    fun symbols() = Arbitraries.chars().map { symbol -> symbol.toString() }
+}


### PR DESCRIPTION
#24 
  
## 🐞 Problem to Solve

Creates the symbol primitive.

## 💡 Solution

The Symbol primitive handles the representation of the Prefix, and also its string representation.

---
  
  ✅ **Checklist**

- [X] The PR includes a clear and descriptive title
- [X] Related issue(s) are linked in the PR body
- [X] The solution is explained thoroughly
- [X] Tests or proofs are included

