### PR TITLE
[KISU-39] Creates basic units

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -2,7 +2,6 @@ import io.gitlab.arturbosch.detekt.Detekt
 
 plugins {
     kotlin("jvm")
-    alias(libs.plugins.klint)
     alias(libs.plugins.dokka)
     alias(libs.plugins.detekt)
 }

--- a/lib/src/main/kotlin/org/kisu/BigDecimals.kt
+++ b/lib/src/main/kotlin/org/kisu/BigDecimals.kt
@@ -21,6 +21,25 @@ val BigDecimal.one: Boolean
     get() = compareTo(BigDecimal.ONE) == 0
 
 /**
+ * Returns `true` if this [BigDecimal] is strictly less than zero.
+ *
+ * Uses [BigDecimal.signum] to determine the sign of the number.
+ */
+val BigDecimal.negative: Boolean
+    get() = signum() == -1
+
+/**
+ * Returns `true` if this [BigDecimal] has a non-zero fractional part.
+ *
+ * Trailing zeros are stripped before checking the [java.math.BigDecimal.scale], so values like `5.0` or `2.000` are
+ * treated as integers.
+ *
+ * A positive scale after stripping indicates digits exist after the decimal point.
+ */
+val BigDecimal.hasFraction: Boolean
+    get() = stripTrailingZeros().scale() > 0
+
+/**
  * Converts this [Number] to a [BigDecimal] instance.
  *
  * Handles common numeric types efficiently:

--- a/lib/src/main/kotlin/org/kisu/prefixes/Binary.kt
+++ b/lib/src/main/kotlin/org/kisu/prefixes/Binary.kt
@@ -1,7 +1,9 @@
 package org.kisu.prefixes
 
 import org.kisu.prefixes.primitives.Representation
+import org.kisu.prefixes.primitives.StandardSystem
 import org.kisu.prefixes.primitives.Symbol
+import org.kisu.prefixes.primitives.System
 import java.math.BigDecimal
 
 /**
@@ -26,37 +28,40 @@ import java.math.BigDecimal
 enum class Binary(
     override val factor: BigDecimal,
     symbol: String,
-) : Prefix<Binary>, Symbol by Representation(symbol) {
+) : Prefix<Binary>, System<Binary> by StandardSystem(Binary::class), Symbol by Representation(symbol) {
     /** Base unit with factor 1 (2^0). */
     BASE(BigDecimal.ONE, ""),
 
     /** Kibi — 2¹⁰ = 1,024 */
-    KIBI(BigDecimal("1024"), "Ki"),
+    KIBI(10, "Ki"),
 
     /** Mebi — 2²⁰ = 1,048,576 */
-    MEBI(BigDecimal("1048576"), "Mi"),
+    MEBI(20, "Mi"),
 
     /** Gibi — 2³⁰ = 1,073,741,824 */
-    GIBI(BigDecimal("1073741824"), "Gi"),
+    GIBI(30, "Gi"),
 
     /** Tebi — 2⁴⁰ = 1,099,511,627,776 */
-    TEBI(BigDecimal("1099511627776"), "Ti"),
+    TEBI(40, "Ti"),
 
     /** Pebi — 2⁵⁰ = 1,125,899,906,842,624 */
-    PEBI(BigDecimal("1125899906842624"), "Pi"),
+    PEBI(50, "Pi"),
 
     /** Exbi — 2⁶⁰ = 1,152,921,504,606,846,976 */
-    EXBI(BigDecimal("1152921504606846976"), "Ei"),
+    EXBI(60, "Ei"),
 
     /** Zebi — 2⁷⁰ = 1,180,591,620,717,411,303,424 */
-    ZEBI(BigDecimal("1180591620717411303424"), "Zi"),
+    ZEBI(70, "Zi"),
 
     /** Yobi — 2⁸⁰ = 1,208,925,819,614,629,174,706,176 */
-    YOBI(BigDecimal("1208925819614629174706176"), "Yi"),
+    YOBI(80, "Yi"),
 
     /** Robi — 2⁹⁰ = 1,237,940,039,285,380,274,899,124,224 */
-    ROBI(BigDecimal("1237940039285380274899124224"), "Ri"),
+    ROBI(90, "Ri"),
 
     /** Quebi — 2¹⁰⁰ = 1,267,650,600,228,229,401,496,703,205,376 */
-    QUEBI(BigDecimal("1267650600228229401496703205376"), "Qi"),
+    QUEBI(100, "Qi"),
+    ;
+
+    constructor(power: Int, symbol: String) : this(factor = BigDecimal.TWO.pow(power), symbol)
 }

--- a/lib/src/main/kotlin/org/kisu/prefixes/Decimal.kt
+++ b/lib/src/main/kotlin/org/kisu/prefixes/Decimal.kt
@@ -5,7 +5,6 @@ import org.kisu.prefixes.primitives.StandardSystem
 import org.kisu.prefixes.primitives.Symbol
 import org.kisu.prefixes.primitives.System
 import java.math.BigDecimal
-import java.math.BigInteger
 
 /**
  * The `Decimal` prefix system defines unit prefixes based on powers of 1000 (10³).
@@ -38,32 +37,35 @@ enum class Decimal(
     BASE(BigDecimal.ONE, ""),
 
     /** 1000¹ = 1,000 */
-    KILO(BigDecimal(BigInteger("1000")), "k"),
+    KILO(3, "k"),
 
     /** 1000² = 1,000,000 */
-    MEGA(BigDecimal(BigInteger("1000000")), "M"),
+    MEGA(6, "M"),
 
     /** 1000³ = 1,000,000,000 */
-    GIGA(BigDecimal(BigInteger("1000000000")), "G"),
+    GIGA(9, "G"),
 
     /** 1000⁴ = 1,000,000,000,000 */
-    TERA(BigDecimal(BigInteger("1000000000000")), "T"),
+    TERA(12, "T"),
 
     /** 1000⁵ = 1,000,000,000,000,000 */
-    PETA(BigDecimal(BigInteger("1000000000000000")), "P"),
+    PETA(15, "P"),
 
     /** 1000⁶ = 1,000,000,000,000,000,000 */
-    EXA(BigDecimal(BigInteger("1000000000000000000")), "E"),
+    EXA(18, "E"),
 
     /** 1000⁷ = 1,000,000,000,000,000,000,000 */
-    ZETTA(BigDecimal(BigInteger("1000000000000000000000")), "Z"),
+    ZETTA(21, "Z"),
 
     /** 1000⁸ = 1,000,000,000,000,000,000,000,000 */
-    YOTTA(BigDecimal(BigInteger("1000000000000000000000000")), "Y"),
+    YOTTA(24, "Y"),
 
     /** 1000⁹ = 1,000,000,000,000,000,000,000,000,000 */
-    RONNA(BigDecimal(BigInteger("1000000000000000000000000000")), "R"),
+    RONNA(27, "R"),
 
     /** 1000¹⁰ = 1,000,000,000,000,000,000,000,000,000,000 */
-    QUETTA(BigDecimal(BigInteger("1000000000000000000000000000000")), "Q"),
+    QUETTA(30, "Q"),
+    ;
+
+    constructor(power: Int, symbol: String) : this(factor = BigDecimal.TEN.pow(power), symbol)
 }

--- a/lib/src/main/kotlin/org/kisu/prefixes/Metric.kt
+++ b/lib/src/main/kotlin/org/kisu/prefixes/Metric.kt
@@ -84,38 +84,41 @@ enum class Metric(
     BASE(BigDecimal.ONE, ""),
 
     /** 10¹ = 10 */
-    DECA(BigDecimal(BigInteger("10")), "da"),
+    DECA(1, "da"),
 
     /** 10² = 100 */
-    HECTO(BigDecimal(BigInteger("100")), "h"),
+    HECTO(2, "h"),
 
     /** 10³ = 1,000 */
-    KILO(BigDecimal(BigInteger("1000")), "k"),
+    KILO(3, "k"),
 
     /** 10⁶ = 1,000,000 */
-    MEGA(BigDecimal(BigInteger("1000000")), "M"),
+    MEGA(6, "M"),
 
     /** 10⁹ = 1,000,000,000 */
-    GIGA(BigDecimal(BigInteger("1000000000")), "G"),
+    GIGA(9, "G"),
 
     /** 10¹² = 1,000,000,000,000 */
-    TERA(BigDecimal(BigInteger("1000000000000")), "T"),
+    TERA(12, "T"),
 
     /** 10¹⁵ = 1,000,000,000,000,000 */
-    PETA(BigDecimal(BigInteger("1000000000000000")), "P"),
+    PETA(15, "P"),
 
     /** 10¹⁸ = 1,000,000,000,000,000,000 */
-    EXA(BigDecimal(BigInteger("1000000000000000000")), "E"),
+    EXA(18, "E"),
 
     /** 10²¹ = 1,000,000,000,000,000,000,000 */
-    ZETTA(BigDecimal(BigInteger("1000000000000000000000")), "Z"),
+    ZETTA(21, "Z"),
 
     /** 10²⁴ = 1,000,000,000,000,000,000,000,000 */
-    YOTTA(BigDecimal(BigInteger("1000000000000000000000000")), "Y"),
+    YOTTA(24, "Y"),
 
     /** 10²⁷ = 1,000,000,000,000,000,000,000,000,000 */
-    RONNA(BigDecimal(BigInteger("1000000000000000000000000000")), "R"),
+    RONNA(27, "R"),
 
     /** 10³⁰ = 1,000,000,000,000,000,000,000,000,000,000 */
-    QUETTA(BigDecimal(BigInteger("1000000000000000000000000000000")), "Q"),
+    QUETTA(30, "Q"),
+    ;
+
+    constructor(power: Int, symbol: String) : this(factor = BigDecimal.TEN.pow(power), symbol)
 }

--- a/lib/src/main/kotlin/org/kisu/prefixes/Prefix.kt
+++ b/lib/src/main/kotlin/org/kisu/prefixes/Prefix.kt
@@ -2,6 +2,7 @@ package org.kisu.prefixes
 
 import org.kisu.KisuConfig
 import org.kisu.prefixes.primitives.Symbol
+import org.kisu.prefixes.primitives.System
 import java.math.BigDecimal
 
 /**
@@ -79,3 +80,15 @@ interface Prefix<Self : Prefix<Self>> : Symbol, Comparable<Prefix<Self>> {
      */
     override fun compareTo(other: Prefix<Self>): Int = factor.compareTo(other.factor)
 }
+
+/**
+ * Returns `true` if this [Prefix] is the **canonical** or base unit prefix for its system.
+ *
+ * In most systems, this typically corresponds to the unit with a factor of 1 (e.g., no prefix in metric,
+ * or `BASE` in binary). It compares the current prefix with the system-defined
+ * [org.kisu.prefixes.primitives.System.canonical] prefix.
+ *
+ * @return `true` if this prefix is the canonical base unit, `false` otherwise.
+ */
+val <P> P.isCanonical: Boolean where P : Prefix<P>, P : System<P>
+    get() = this == canonical

--- a/lib/src/main/kotlin/org/kisu/units/Measure.kt
+++ b/lib/src/main/kotlin/org/kisu/units/Measure.kt
@@ -139,6 +139,9 @@ abstract class Measure<Prefix, Self : Measure<Prefix, Self>> protected construct
      * @return A new [Measure] instance using the new [prefix] and the converted [magnitude].
      */
     fun to(other: Prefix): Self {
+        if (prefix == other) {
+            return self
+        }
         val conversion = prefix.to(other)
         return invoke(magnitude * conversion, other)
     }

--- a/lib/src/main/kotlin/org/kisu/units/Measure.kt
+++ b/lib/src/main/kotlin/org/kisu/units/Measure.kt
@@ -89,7 +89,9 @@ abstract class Measure<Prefix, Self : Measure<Prefix, Self>> protected construct
      * ```
      */
     val canonical: Self by lazy {
-        if (!magnitude.zero) {
+        if (prefix == prefix.canonical) {
+            self
+        } else if (!magnitude.zero) {
             to(prefix.canonical)
         } else {
             invoke(magnitude, prefix.canonical)

--- a/lib/src/main/kotlin/org/kisu/units/base/Amount.kt
+++ b/lib/src/main/kotlin/org/kisu/units/base/Amount.kt
@@ -1,0 +1,57 @@
+package org.kisu.units.base
+
+import org.kisu.prefixes.Metric
+import org.kisu.units.Measure
+import org.kisu.units.base.Amount.Companion.AVOGADROS_NUMBER
+import org.kisu.units.exceptions.NegativeAmountOfSubstance
+import java.math.BigDecimal
+
+/**
+ * Represents the physical quantity of **amount of substance**, measured in moles (mol).
+ *
+ * This class models the SI base unit for counting discrete entities like atoms, molecules, or particles in a substance.
+ * One mole corresponds to [AVOGADROS_NUMBER] elementary entities, typically used in chemistry and physics.
+ *
+ * The amount is composed of a [magnitude] and an optional metric [prefix], allowing expressions such as millimoles
+ * (mmol), micromoles (µmol), or kilomoles (kmol).
+ *
+ * The value must not be negative, as a physical quantity representing a count of real entities cannot be less than
+ * zero.
+ *
+ * Negative amounts would be physically meaningless in the context of matter.
+ *
+ * Instances of this class are immutable and preserve their precision using [BigDecimal].
+ */
+class Amount private constructor(magnitude: BigDecimal, prefix: Metric) :
+    Measure<Metric, Amount>(magnitude, prefix, SYMBOL) {
+    /**
+     * Creates a new [Amount] with the given [magnitude] and [prefix].
+     *
+     * The magnitude must be zero or positive. A negative amount of substance is not allowed,
+     * as it would represent a negative count of entities, which is physically meaningless.
+     *
+     * @throws NegativeAmountOfSubstance if the magnitude is less than zero.
+     */
+    override fun invoke(
+        magnitude: BigDecimal,
+        prefix: Metric,
+    ): Amount {
+        if (magnitude < BigDecimal.ZERO) {
+            throw NegativeAmountOfSubstance(magnitude, prefix, SYMBOL)
+        }
+        return Amount(magnitude, prefix)
+    }
+
+    companion object {
+        /** The SI symbol for amount of substance: "mol". */
+        private const val SYMBOL = "mol"
+
+        /**
+         * Avogadro's number — the number of entities in one mole:
+         * 6.02214076 × 10²³ entities per mole.
+         *
+         * This is a fundamental physical constant.
+         */
+        val AVOGADROS_NUMBER: BigDecimal = BigDecimal("6.02214076e23")
+    }
+}

--- a/lib/src/main/kotlin/org/kisu/units/base/Current.kt
+++ b/lib/src/main/kotlin/org/kisu/units/base/Current.kt
@@ -1,0 +1,35 @@
+package org.kisu.units.base
+
+import org.kisu.prefixes.Metric
+import org.kisu.units.Measure
+import java.math.BigDecimal
+
+/**
+ * Represents the physical quantity of **electric current**, measured in amperes (A).
+ *
+ * Electric current quantifies the flow of electric charge over time.
+ * One ampere corresponds to one coulomb of charge passing through a point in a circuit per second.
+ *
+ * This quantity is one of the seven SI base units and is typically used to describe the intensity of electrical flow
+ * in conductors, circuits, and electromagnetic systems.
+ *
+ * This class expresses current as a combination of a [magnitude] and a [prefix], supporting values such as
+ * milliamperes (mA), microamperes (µA), or kiloamperes (kA).
+ *
+ * Instances of this class are immutable and use [BigDecimal] for precision.
+ */
+class Current private constructor(magnitude: BigDecimal, prefix: Metric) :
+    Measure<Metric, Current>(magnitude, prefix, SYMBOL) {
+    /**
+     * Creates a new [Current] with the given [magnitude] and [prefix].
+     */
+    override fun invoke(
+        magnitude: BigDecimal,
+        prefix: Metric,
+    ): Current = Current(magnitude, prefix)
+
+    companion object {
+        /** The SI symbol for electric current: "A" (ampere). */
+        private const val SYMBOL = "A"
+    }
+}

--- a/lib/src/main/kotlin/org/kisu/units/base/Information.kt
+++ b/lib/src/main/kotlin/org/kisu/units/base/Information.kt
@@ -1,0 +1,71 @@
+package org.kisu.units.base
+
+import org.kisu.hasFraction
+import org.kisu.negative
+import org.kisu.prefixes.Binary
+import org.kisu.prefixes.isCanonical
+import org.kisu.units.Measure
+import org.kisu.units.exceptions.NegativeInformation
+import org.kisu.units.exceptions.SubBitInformation
+import java.math.BigDecimal
+
+/**
+ * Represents the quantity of **digital information**, measured in bits.
+ *
+ * This class models the fundamental unit of information in computing and digital communications: the **bit** (binary
+ * digit).
+ *
+ * It supports binary prefixes such as kibibit (Ki), mebibit (Mi), gibibit (Gi), etc., allowing precise modeling of
+ * quantities such as storage, memory, and bandwidth.
+ *
+ * - The **smallest representable unit** is a single bit.
+ * - Negative values are not permitted, as information content cannot be less than zero.
+ * - In canonical form (i.e., using the base prefix), the quantity must also be **whole** — fractional bits have no
+ *   meaningful interpretation in physical or computational systems.
+ *
+ * This class enforces those constraints and will reject values that violate them. Precision is maintained using
+ * [BigDecimal].
+ *
+ * Instances are immutable and safely validated at construction.
+ */
+class Information private constructor(magnitude: BigDecimal, prefix: Binary) :
+    Measure<Binary, Information>(magnitude, prefix, SYMBOL) {
+    /**
+     * Creates a new [Information] quantity with the given [magnitude] and [prefix].
+     *
+     * Constraints:
+     * - The [magnitude] must be strictly positive; negative information is physically meaningless.
+     * - If the [prefix] is canonical (i.e., no prefix, representing raw bits), the [magnitude] must not include
+     * fractional parts.
+     *   Fractional bits are not representable as atomic units of digital information.
+     *
+     * If these constraints are violated:
+     * - A [NegativeInformation] exception is thrown for negative values.
+     * - A [SubBitInformation] exception is thrown for fractional bit values in canonical form.
+     *
+     * @param magnitude The magnitude of the information quantity.
+     * @param prefix The binary prefix to apply (e.g., Ki, Mi, Gi, etc.).
+     * @return A new [Information] instance with the specified magnitude and prefix.
+     * @throws NegativeInformation if the value is negative.
+     * @throws SubBitInformation if a non-integer bit value is used with the base unit.
+     */
+    override fun invoke(
+        magnitude: BigDecimal,
+        prefix: Binary,
+    ): Information {
+        if (magnitude.negative) {
+            throw NegativeInformation(magnitude, prefix, SYMBOL)
+        }
+        if (prefix.isCanonical && magnitude.hasFraction) {
+            throw SubBitInformation(magnitude, SYMBOL)
+        }
+        val information = Information(magnitude, prefix)
+        information.canonical // Forces evaluation for potential validation during construction
+        return information
+    }
+
+    companion object {
+        /** The unit symbol for digital information: "bit". */
+        private const val SYMBOL = "bit"
+    }
+}

--- a/lib/src/main/kotlin/org/kisu/units/base/Length.kt
+++ b/lib/src/main/kotlin/org/kisu/units/base/Length.kt
@@ -1,0 +1,31 @@
+package org.kisu.units.base
+
+import org.kisu.prefixes.Metric
+import org.kisu.units.Measure
+import java.math.BigDecimal
+
+/**
+ * Represents the physical quantity of **length**, measured in metres (m).
+ *
+ * Length describes the extent of objects or the distance between points in space. This class models length
+ * as defined by the SI system, using the metre as the base unit and supporting metric prefixes such as millimetre (mm),
+ * centimetre (cm), and kilometre (km).
+ *
+ * The quantity is expressed with a [magnitude] and a [prefix], enabling precise representation of both small- and
+ * large-scale measurements using [BigDecimal] for accuracy.
+ */
+class Length private constructor(magnitude: BigDecimal, prefix: Metric) :
+    Measure<Metric, Length>(magnitude, prefix, SYMBOL) {
+    /**
+     * Creates a new [Length] quantity with the given [magnitude] and [prefix].
+     */
+    override fun invoke(
+        magnitude: BigDecimal,
+        prefix: Metric,
+    ): Length = Length(magnitude, prefix)
+
+    companion object {
+        /** The SI symbol for length: "m" (metre). */
+        private const val SYMBOL = "m"
+    }
+}

--- a/lib/src/main/kotlin/org/kisu/units/base/LuminousIntensity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/base/LuminousIntensity.kt
@@ -1,0 +1,51 @@
+package org.kisu.units.base
+
+import org.kisu.negative
+import org.kisu.prefixes.Metric
+import org.kisu.units.Measure
+import org.kisu.units.exceptions.NegativeLuminousIntensity
+import java.math.BigDecimal
+
+/**
+ * Represents the physical quantity of **luminous intensity**, measured in candelas (cd).
+ *
+ * Luminous intensity quantifies the perceived brightness emitted by a light source in a specific direction.
+ * It is one of the seven SI base quantities and is measured in **candelas (cd)**.
+ *
+ * The [magnitude] must not be negative. Negative luminous intensity is physically meaningless because intensity
+ * describes an emission — light cannot be “less than none.” A value of zero represents no light output, and
+ * any non-zero value indicates the intensity of light emitted.
+ *
+ * This class models the quantity as a combination of a [magnitude] and a [prefix], enabling precise values
+ * such as milllicandelas (mcd) or kilocandelas (kcd).
+ *
+ * All values are stored with high precision using [BigDecimal], and instances are immutable.
+ */
+class LuminousIntensity private constructor(magnitude: BigDecimal, prefix: Metric) :
+    Measure<Metric, LuminousIntensity>(magnitude, prefix, SYMBOL) {
+    /**
+     * Creates a new [LuminousIntensity] quantity with the given [magnitude] and [prefix].
+     *
+     * The magnitude must be zero or positive. Negative luminous intensity is not permitted, as it would imply
+     * a negative emission of light, which is not physically possible.
+     *
+     * @param magnitude The numeric value of the luminous intensity.
+     * @param prefix The metric prefix to apply (e.g., m, k).
+     * @return A validated [LuminousIntensity] instance.
+     * @throws NegativeLuminousIntensity if the magnitude is less than zero.
+     */
+    override fun invoke(
+        magnitude: BigDecimal,
+        prefix: Metric,
+    ): LuminousIntensity {
+        if (magnitude.negative) {
+            throw NegativeLuminousIntensity(magnitude, prefix, SYMBOL)
+        }
+        return LuminousIntensity(magnitude, prefix)
+    }
+
+    companion object {
+        /** The SI symbol for luminous intensity: "cd" (candela). */
+        private const val SYMBOL = "cd"
+    }
+}

--- a/lib/src/main/kotlin/org/kisu/units/base/Mass.kt
+++ b/lib/src/main/kotlin/org/kisu/units/base/Mass.kt
@@ -1,0 +1,52 @@
+package org.kisu.units.base
+
+import org.kisu.negative
+import org.kisu.prefixes.Metric
+import org.kisu.units.Measure
+import org.kisu.units.exceptions.NegativeMass
+import java.math.BigDecimal
+
+/**
+ * Represents the physical quantity of **mass**, measured in grams (g).
+ *
+ * Mass quantifies the amount of matter contained in a physical object. It is one of the most fundamental physical
+ * properties and a key SI base quantity.
+ *
+ * Mass values must not be negative. A negative mass is not physically meaningful — it would imply the existence of
+ * “negative matter,” which is not observed in any real-world context. A mass of zero may be used to represent the
+ * absence of matter, but any valid amount of substance must have a non-negative mass.
+ *
+ * This class models mass as a combination of a [magnitude] and a [prefix], allowing precise values such as milligrams
+ * (mg), kilograms (kg), or megagrams (Mg). All values are represented using [BigDecimal] for high-precision
+ * calculations.
+ *
+ * Instances of this class are immutable and validated at construction.
+ */
+class Mass private constructor(magnitude: BigDecimal, prefix: Metric) :
+    Measure<Metric, Mass>(magnitude, prefix, SYMBOL) {
+    /**
+     * Creates a new [Mass] quantity with the given [magnitude] and [prefix].
+     *
+     * The [magnitude] must be zero or positive. Negative mass is not permitted, as it represents a physically
+     * invalid state — mass can be absent (zero), but never less than zero.
+     *
+     * @param magnitude The numeric value of the mass.
+     * @param prefix The metric prefix to apply (e.g., m, k, M).
+     * @return A validated [Mass] instance.
+     * @throws NegativeMass if the magnitude is less than zero.
+     */
+    override fun invoke(
+        magnitude: BigDecimal,
+        prefix: Metric,
+    ): Mass {
+        if (magnitude.negative) {
+            throw NegativeMass(magnitude, prefix, SYMBOL)
+        }
+        return Mass(magnitude, prefix)
+    }
+
+    companion object {
+        /** The symbol for mass: "g" (gram). */
+        private const val SYMBOL = "g"
+    }
+}

--- a/lib/src/main/kotlin/org/kisu/units/base/Temperature.kt
+++ b/lib/src/main/kotlin/org/kisu/units/base/Temperature.kt
@@ -1,0 +1,54 @@
+package org.kisu.units.base
+
+import org.kisu.negative
+import org.kisu.prefixes.Metric
+import org.kisu.units.Measure
+import org.kisu.units.exceptions.NegativeTemperature
+import java.math.BigDecimal
+
+/**
+ * Represents the physical quantity of **thermodynamic temperature**, measured in kelvin (K).
+ *
+ * Temperature quantifies the thermal state of a system in absolute terms,
+ * using the **kelvin** as the SI base unit. Unlike degrees Celsius or Fahrenheit, the kelvin scale
+ * starts at **absolute zero**, the lowest possible temperature in nature, where particles have
+ * minimal thermal motion.
+ *
+ * Because the kelvin scale is absolute, **negative values are not physically meaningful** — no system
+ * can exist below absolute zero. A temperature of zero kelvin represents a complete absence of thermal energy.
+ *
+ * This class models temperature as a combination of a [magnitude] and an optional metric [prefix],
+ * enabling precise representation of values such as millikelvin (mK) or kilokelvin (kK).
+ *
+ * The magnitude is stored using [BigDecimal] for accuracy. All instances are validated to ensure they
+ * respect physical constraints and are immutable once created.
+ */
+class Temperature private constructor(magnitude: BigDecimal, prefix: Metric) :
+    Measure<Metric, Temperature>(magnitude, prefix, SYMBOL) {
+    /**
+     * Creates a new [Temperature] quantity with the given [magnitude] and [prefix].
+     *
+     * The [magnitude] must be zero or positive. Negative temperatures are not permitted in kelvin,
+     * as they would represent values below absolute zero — a condition that is physically impossible
+     * in classical thermodynamics.
+     *
+     * @param magnitude The numeric value of the temperature.
+     * @param prefix The metric prefix to apply (e.g., m, k).
+     * @return A validated [Temperature] instance.
+     * @throws NegativeTemperature if the magnitude is less than zero.
+     */
+    override fun invoke(
+        magnitude: BigDecimal,
+        prefix: Metric,
+    ): Temperature {
+        if (magnitude.negative) {
+            throw NegativeTemperature(magnitude, prefix, SYMBOL)
+        }
+        return Temperature(magnitude, prefix)
+    }
+
+    companion object {
+        /** The SI symbol for temperature: "K" (kelvin). */
+        private const val SYMBOL = "K"
+    }
+}

--- a/lib/src/main/kotlin/org/kisu/units/base/Time.kt
+++ b/lib/src/main/kotlin/org/kisu/units/base/Time.kt
@@ -1,0 +1,50 @@
+package org.kisu.units.base
+
+import org.kisu.negative
+import org.kisu.prefixes.Metric
+import org.kisu.units.Measure
+import org.kisu.units.exceptions.NegativeTime
+import java.math.BigDecimal
+
+/**
+ * Represents the physical quantity of **time**, measured in seconds (s).
+ *
+ * Time quantifies the duration of events or intervals. It is one of the fundamental SI base quantities
+ * and is universally measured in **seconds**. This class allows precise modeling of durations such as
+ * milliseconds (ms), microseconds (µs), or kiloseconds (ks), using metric prefixes.
+ *
+ * Time values must not be negative. In physical systems and real-world contexts, negative time has no
+ * meaning — you cannot go back and create a duration with a negative length. Zero represents an
+ * instantaneous or null duration, while positive values represent elapsed or measurable intervals.
+ *
+ * The magnitude is stored using [BigDecimal] to ensure high precision. Instances of this class are immutable
+ * and validated to reflect physical reality.
+ */
+class Time private constructor(magnitude: BigDecimal, prefix: Metric) :
+    Measure<Metric, Time>(magnitude, prefix, SYMBOL) {
+    /**
+     * Creates a new [Time] quantity with the given [magnitude] and [prefix].
+     *
+     * The [magnitude] must be zero or positive. Negative time is not allowed because it would imply a
+     * backward duration, which is not valid when modeling time as an interval or duration.
+     *
+     * @param magnitude The numeric value of the time quantity.
+     * @param prefix The metric prefix to apply (e.g., m, µ, k).
+     * @return A validated [Time] instance.
+     * @throws NegativeTime if the magnitude is less than zero.
+     */
+    override fun invoke(
+        magnitude: BigDecimal,
+        prefix: Metric,
+    ): Time {
+        if (magnitude.negative) {
+            throw NegativeTime(magnitude, prefix, SYMBOL)
+        }
+        return Time(magnitude, prefix)
+    }
+
+    companion object {
+        /** The SI symbol for time: "s" (second). */
+        private const val SYMBOL = "s"
+    }
+}

--- a/lib/src/main/kotlin/org/kisu/units/distance/Meter.kt
+++ b/lib/src/main/kotlin/org/kisu/units/distance/Meter.kt
@@ -1,3 +1,0 @@
-package org.kisu.units.distance
-
-internal const val METER = "meter"

--- a/lib/src/main/kotlin/org/kisu/units/exceptions/NegativeAmountOfSubstance.kt
+++ b/lib/src/main/kotlin/org/kisu/units/exceptions/NegativeAmountOfSubstance.kt
@@ -1,0 +1,19 @@
+package org.kisu.units.exceptions
+
+import org.kisu.prefixes.Metric
+import java.math.BigDecimal
+
+/**
+ * Exception thrown when an attempt is made to create or represent
+ * an amount of substance with a negative value.
+ *
+ * Negative amounts of substance are physically invalid, as they would
+ * imply a negative quantity of entities, which is impossible.
+ *
+ * @param value The invalid negative magnitude provided.
+ * @param prefix The metric prefix associated with the value.
+ * @param symbol The unit symbol (e.g., "mol").
+ */
+class NegativeAmountOfSubstance(value: BigDecimal, prefix: Metric, symbol: String) : ArithmeticException(
+    "An amount of substance cannot be negative: received $value $prefix$symbol",
+)

--- a/lib/src/main/kotlin/org/kisu/units/exceptions/NegativeInformation.kt
+++ b/lib/src/main/kotlin/org/kisu/units/exceptions/NegativeInformation.kt
@@ -1,0 +1,19 @@
+package org.kisu.units.exceptions
+
+import org.kisu.prefixes.Binary
+import java.math.BigDecimal
+
+/**
+ * Exception thrown when an attempt is made to create or represent
+ * an information quantity with a negative value.
+ *
+ * Negative information quantities are invalid, as information content
+ * cannot be less than zero bits.
+ *
+ * @param value The invalid negative magnitude provided.
+ * @param prefix The binary prefix associated with the value.
+ * @param symbol The unit symbol (e.g., "bit").
+ */
+class NegativeInformation(value: BigDecimal, prefix: Binary, symbol: String) : ArithmeticException(
+    "Information quantity cannot be negative: received $value $prefix$symbol",
+)

--- a/lib/src/main/kotlin/org/kisu/units/exceptions/NegativeLuminousIntensity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/exceptions/NegativeLuminousIntensity.kt
@@ -1,0 +1,19 @@
+package org.kisu.units.exceptions
+
+import org.kisu.prefixes.Metric
+import java.math.BigDecimal
+
+/**
+ * Exception thrown when an attempt is made to create or represent
+ * a luminous intensity with a negative value.
+ *
+ * Negative luminous intensity is physically impossible, as it would imply
+ * a light source emitting a negative amount of light.
+ *
+ * @param value The invalid negative magnitude provided.
+ * @param prefix The metric prefix associated with the value.
+ * @param symbol The unit symbol (e.g., "cd").
+ */
+class NegativeLuminousIntensity(value: BigDecimal, prefix: Metric, symbol: String) : ArithmeticException(
+    "Luminous intensity cannot be negative: received $value $prefix$symbol",
+)

--- a/lib/src/main/kotlin/org/kisu/units/exceptions/NegativeMass.kt
+++ b/lib/src/main/kotlin/org/kisu/units/exceptions/NegativeMass.kt
@@ -1,0 +1,19 @@
+package org.kisu.units.exceptions
+
+import org.kisu.prefixes.Metric
+import java.math.BigDecimal
+
+/**
+ * Exception thrown when an attempt is made to create or represent
+ * a mass with a negative value.
+ *
+ * Negative mass is physically invalid, as it would imply the presence
+ * of “negative matter,” which does not exist in known physics.
+ *
+ * @param value The invalid negative magnitude provided.
+ * @param prefix The metric prefix associated with the value.
+ * @param symbol The unit symbol (e.g., "g").
+ */
+class NegativeMass(value: BigDecimal, prefix: Metric, symbol: String) : ArithmeticException(
+    "Mass cannot be negative: received $value $prefix$symbol",
+)

--- a/lib/src/main/kotlin/org/kisu/units/exceptions/NegativeTemperature.kt
+++ b/lib/src/main/kotlin/org/kisu/units/exceptions/NegativeTemperature.kt
@@ -1,0 +1,19 @@
+package org.kisu.units.exceptions
+
+import org.kisu.prefixes.Metric
+import java.math.BigDecimal
+
+/**
+ * Exception thrown when an attempt is made to create or represent
+ * a temperature below absolute zero.
+ *
+ * Temperatures below absolute zero are physically impossible, as absolute zero
+ * (0 K) is the lowest limit of thermodynamic temperature.
+ *
+ * @param value The invalid temperature magnitude provided.
+ * @param prefix The metric prefix associated with the value.
+ * @param symbol The unit symbol (e.g., "K").
+ */
+class NegativeTemperature(value: BigDecimal, prefix: Metric, symbol: String) : ArithmeticException(
+    "Temperature cannot be below absolute zero: received $value $prefix$symbol",
+)

--- a/lib/src/main/kotlin/org/kisu/units/exceptions/NegativeTime.kt
+++ b/lib/src/main/kotlin/org/kisu/units/exceptions/NegativeTime.kt
@@ -1,0 +1,19 @@
+package org.kisu.units.exceptions
+
+import org.kisu.prefixes.Metric
+import java.math.BigDecimal
+
+/**
+ * Exception thrown when an attempt is made to create or represent
+ * a time duration with a negative value.
+ *
+ * Negative time durations are invalid because time intervals
+ * cannot be less than zero — negative durations have no physical meaning.
+ *
+ * @param value The invalid negative magnitude provided.
+ * @param prefix The metric prefix associated with the value.
+ * @param symbol The unit symbol (e.g., "s").
+ */
+class NegativeTime(value: BigDecimal, prefix: Metric, symbol: String) : ArithmeticException(
+    "Time duration cannot be negative: received $value $prefix$symbol",
+)

--- a/lib/src/main/kotlin/org/kisu/units/exceptions/SubBitInformation.kt
+++ b/lib/src/main/kotlin/org/kisu/units/exceptions/SubBitInformation.kt
@@ -1,0 +1,17 @@
+package org.kisu.units.exceptions
+
+import java.math.BigDecimal
+
+/**
+ * Exception thrown when an attempt is made to create or represent
+ * an information quantity smaller than one bit in canonical form.
+ *
+ * Information quantities must be whole numbers of bits when represented
+ * without a binary prefix, as fractional bits are not physically meaningful.
+ *
+ * @param value The invalid fractional magnitude provided.
+ * @param symbol The unit symbol (e.g., "bit").
+ */
+class SubBitInformation(value: BigDecimal, symbol: String) : ArithmeticException(
+    "Information values must be whole. Received a non-quantized value: $value $symbol",
+)

--- a/lib/src/test/kotlin/org/kisu/BigDecimalsTest.kt
+++ b/lib/src/test/kotlin/org/kisu/BigDecimalsTest.kt
@@ -11,24 +11,59 @@ import io.kotest.property.arbitrary.filter
 import io.kotest.property.arbitrary.float
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.long
+import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.short
 import io.kotest.property.checkAll
+import org.kisu.test.generators.bigDecimal
 import java.math.BigDecimal
+import java.math.BigInteger
 
 class BigDecimalsTest : StringSpec({
-    "BigDecimal is detected as zero" {
-        BigDecimal.ZERO.zero.shouldBeTrue()
+    "number is detected as zero" {
+        checkAll(
+            Arb.int(range = 0..40)
+                .map { scale -> BigDecimal(BigInteger("0"), scale) },
+        ) { number ->
+            number.zero.shouldBeTrue()
+        }
     }
 
-    "zero returns false when it is not zero" {
-        checkAll(Arb.bigDecimal().filter { !it.zero }) { number ->
+    "number is detected as not zero" {
+        checkAll(Arb.bigDecimal().filter { number -> number.compareTo(BigDecimal.ZERO) != 0 }) { number ->
             number.zero.shouldBeFalse()
+        }
+    }
+
+    "number is detected as one" {
+        checkAll(
+            Arb.int(range = 0..40)
+                .map { scale -> BigDecimal.ONE.setScale(scale) },
+        ) { number ->
+            number.one.shouldBeTrue()
+        }
+    }
+
+    "number is detected as not one" {
+        checkAll(Arb.bigDecimal().filter { number -> number.compareTo(BigDecimal.ONE) != 0 }) { number ->
+            number.one.shouldBeFalse()
         }
     }
 
     "converts a BigDecimal into a BigDecimal" {
         checkAll(Arb.bigDecimal()) { number ->
             number.bigDecimal shouldBe number
+        }
+    }
+
+    "a number is decimal" {
+        checkAll(Arb.bigDecimal(minFractionalDigits = 1, maxDigits = 5)) { number ->
+            number.hasFraction.shouldBeTrue()
+        }
+    }
+
+    "a number is integer" {
+        checkAll(Arb.int().map { number -> number.bigDecimal }) { number ->
+            number.hasFraction.shouldBeFalse()
         }
     }
 
@@ -59,6 +94,18 @@ class BigDecimalsTest : StringSpec({
     "converts a Double into a BigDecimal" {
         checkAll(Arb.double().filter { it.isFinite() && !it.isNaN() }) { number ->
             number.bigDecimal shouldBe BigDecimal(number.toString())
+        }
+    }
+
+    "a negative number is tagged as negative" {
+        checkAll(Arb.bigDecimal().filter { it.signum() == -1 }) { number ->
+            number.negative.shouldBeTrue()
+        }
+    }
+
+    "a positive or zero number is not tagged as negative" {
+        checkAll(Arb.bigDecimal().filter { it.signum() != -1 }) { number ->
+            number.negative.shouldBeFalse()
         }
     }
 })

--- a/lib/src/test/kotlin/org/kisu/test/generators/BigDecimals.kt
+++ b/lib/src/test/kotlin/org/kisu/test/generators/BigDecimals.kt
@@ -1,0 +1,27 @@
+package org.kisu.test.generators
+
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.arbitrary
+import io.kotest.property.arbitrary.bigInt
+import io.kotest.property.arbitrary.filter
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.next
+import java.math.BigDecimal
+import java.math.BigInteger
+
+fun Arb.Companion.bigDecimal(
+    maxDigits: Int = 10,
+    minFractionalDigits: Int = 1,
+    maxFractionalDigits: Int = 5,
+): Arb<BigDecimal> {
+    return arbitrary { random ->
+        val integerPart =
+            Arb.bigInt(0..BigInteger.TEN.pow(maxDigits).toInt())
+                .filter { it % BigInteger.TEN != BigInteger.ZERO }
+                .next(random)
+        val scale = Arb.int(minFractionalDigits..maxFractionalDigits).next(random)
+        val sign = if (random.random.nextBoolean()) BigDecimal.ONE else BigDecimal.ONE.negate()
+
+        BigDecimal(BigInteger(integerPart.toString()), scale).multiply(sign)
+    }
+}


### PR DESCRIPTION
Closes #39 
  
## 🐞 Problem to Solve

The KISU library lacked built-in representations of the seven SI base units, which are foundational to scientific and technical measurement systems. Without these units, the library cannot express or operate on fundamental quantities like length, mass, or temperature in a standardized and extensible way.

## 💡 Solution

This PR introduces the seven SI base units as distinct types within the KISU library:

- **Length** (m) 
- **Mass** (kg)
- **Time** (s)
- **Electric current** (A)
- **Temperature** (K)
- **Amount** (mol)
- **Luminous intensity** (cd) 
- **Information** (bit)
---
  
  ✅ **Checklist**

- [X] The PR includes a clear and descriptive title
- [X] Related issue(s) are linked in the PR body
- [X] The solution is explained thoroughly
- [ ] Tests or proofs are included

