### PR TITLE
[KISU-43] Remove constraints of the units

### DIFF
--- a/lib/src/main/kotlin/org/kisu/units/base/Amount.kt
+++ b/lib/src/main/kotlin/org/kisu/units/base/Amount.kt
@@ -3,7 +3,6 @@ package org.kisu.units.base
 import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Amount.Companion.AVOGADROS_NUMBER
-import org.kisu.units.exceptions.NegativeAmountOfSubstance
 import java.math.BigDecimal
 
 /**
@@ -22,8 +21,8 @@ import java.math.BigDecimal
  *
  * Instances of this class are immutable and preserve their precision using [BigDecimal].
  */
-class Amount private constructor(magnitude: BigDecimal, prefix: Metric) :
-    Measure<Metric, Amount>(magnitude, prefix, SYMBOL, ::invoke) {
+class Amount internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+    Measure<Metric, Amount>(magnitude, prefix, SYMBOL, ::Amount) {
 
     companion object {
         /** The SI symbol for amount of substance: "mol". */
@@ -36,23 +35,5 @@ class Amount private constructor(magnitude: BigDecimal, prefix: Metric) :
          * This is a fundamental physical constant.
          */
         val AVOGADROS_NUMBER: BigDecimal = BigDecimal("6.02214076e23")
-
-        /**
-         * Creates a new [Amount] with the given [magnitude] and [prefix].
-         *
-         * The magnitude must be zero or positive. A negative amount of substance is not allowed,
-         * as it would represent a negative count of entities, which is physically meaningless.
-         *
-         * @throws NegativeAmountOfSubstance if the magnitude is less than zero.
-         */
-        operator fun invoke(
-            magnitude: BigDecimal,
-            prefix: Metric = Metric.BASE,
-        ): Amount {
-            if (magnitude < BigDecimal.ZERO) {
-                throw NegativeAmountOfSubstance(magnitude, prefix, SYMBOL)
-            }
-            return Amount(magnitude, prefix)
-        }
     }
 }

--- a/lib/src/main/kotlin/org/kisu/units/base/Current.kt
+++ b/lib/src/main/kotlin/org/kisu/units/base/Current.kt
@@ -18,19 +18,11 @@ import java.math.BigDecimal
  *
  * Instances of this class are immutable and use [BigDecimal] for precision.
  */
-class Current private constructor(magnitude: BigDecimal, prefix: Metric) :
-    Measure<Metric, Current>(magnitude, prefix, SYMBOL, ::invoke) {
+class Current internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+    Measure<Metric, Current>(magnitude, prefix, SYMBOL, ::Current) {
 
     companion object {
         /** The SI symbol for electric current: "A" (ampere). */
         private const val SYMBOL = "A"
-
-        /**
-         * Creates a new [Current] with the given [magnitude] and [prefix].
-         */
-        operator fun invoke(
-            magnitude: BigDecimal,
-            prefix: Metric = Metric.BASE,
-        ): Current = Current(magnitude, prefix)
     }
 }

--- a/lib/src/main/kotlin/org/kisu/units/base/Information.kt
+++ b/lib/src/main/kotlin/org/kisu/units/base/Information.kt
@@ -1,7 +1,6 @@
 package org.kisu.units.base
 
 import org.kisu.hasFraction
-import org.kisu.negative
 import org.kisu.prefixes.Binary
 import org.kisu.prefixes.isCanonical
 import org.kisu.units.Measure
@@ -28,7 +27,7 @@ import java.math.BigDecimal
  *
  * Instances are immutable and safely validated at construction.
  */
-class Information private constructor(magnitude: BigDecimal, prefix: Binary) :
+class Information private constructor(magnitude: BigDecimal, prefix: Binary = Binary.BASE) :
     Measure<Binary, Information>(magnitude, prefix, SYMBOL, ::invoke) {
 
     companion object {
@@ -58,9 +57,6 @@ class Information private constructor(magnitude: BigDecimal, prefix: Binary) :
             magnitude: BigDecimal,
             prefix: Binary = Binary.BASE,
         ): Information {
-            if (magnitude.negative) {
-                throw NegativeInformation(magnitude, prefix, SYMBOL)
-            }
             if (prefix.isCanonical && magnitude.hasFraction) {
                 throw SubBitInformation(magnitude, SYMBOL)
             }

--- a/lib/src/main/kotlin/org/kisu/units/base/Length.kt
+++ b/lib/src/main/kotlin/org/kisu/units/base/Length.kt
@@ -14,19 +14,11 @@ import java.math.BigDecimal
  * The quantity is expressed with a [magnitude] and a [prefix], enabling precise representation of both small- and
  * large-scale measurements using [BigDecimal] for accuracy.
  */
-class Length private constructor(magnitude: BigDecimal, prefix: Metric) :
-    Measure<Metric, Length>(magnitude, prefix, SYMBOL, ::invoke) {
+class Length internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+    Measure<Metric, Length>(magnitude, prefix, SYMBOL, ::Length) {
 
     companion object {
         /** The SI symbol for length: "m" (metre). */
         private const val SYMBOL = "m"
-
-        /**
-         * Creates a new [Length] quantity with the given [magnitude] and [prefix].
-         */
-        operator fun invoke(
-            magnitude: BigDecimal,
-            prefix: Metric = Metric.BASE,
-        ): Length = Length(magnitude, prefix)
     }
 }

--- a/lib/src/main/kotlin/org/kisu/units/base/LuminousIntensity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/base/LuminousIntensity.kt
@@ -1,9 +1,7 @@
 package org.kisu.units.base
 
-import org.kisu.negative
 import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
-import org.kisu.units.exceptions.NegativeLuminousIntensity
 import java.math.BigDecimal
 
 /**
@@ -21,32 +19,11 @@ import java.math.BigDecimal
  *
  * All values are stored with high precision using [BigDecimal], and instances are immutable.
  */
-class LuminousIntensity private constructor(magnitude: BigDecimal, prefix: Metric) :
-    Measure<Metric, LuminousIntensity>(magnitude, prefix, SYMBOL, ::invoke) {
+class LuminousIntensity internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+    Measure<Metric, LuminousIntensity>(magnitude, prefix, SYMBOL, ::LuminousIntensity) {
 
     companion object {
         /** The SI symbol for luminous intensity: "cd" (candela). */
         private const val SYMBOL = "cd"
-
-        /**
-         * Creates a new [LuminousIntensity] quantity with the given [magnitude] and [prefix].
-         *
-         * The magnitude must be zero or positive. Negative luminous intensity is not permitted, as it would imply
-         * a negative emission of light, which is not physically possible.
-         *
-         * @param magnitude The numeric value of the luminous intensity.
-         * @param prefix The metric prefix to apply (e.g., m, k).
-         * @return A validated [LuminousIntensity] instance.
-         * @throws NegativeLuminousIntensity if the magnitude is less than zero.
-         */
-        operator fun invoke(
-            magnitude: BigDecimal,
-            prefix: Metric = Metric.BASE,
-        ): LuminousIntensity {
-            if (magnitude.negative) {
-                throw NegativeLuminousIntensity(magnitude, prefix, SYMBOL)
-            }
-            return LuminousIntensity(magnitude, prefix)
-        }
     }
 }

--- a/lib/src/main/kotlin/org/kisu/units/base/Mass.kt
+++ b/lib/src/main/kotlin/org/kisu/units/base/Mass.kt
@@ -1,9 +1,7 @@
 package org.kisu.units.base
 
-import org.kisu.negative
 import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
-import org.kisu.units.exceptions.NegativeMass
 import java.math.BigDecimal
 
 /**
@@ -22,32 +20,11 @@ import java.math.BigDecimal
  *
  * Instances of this class are immutable and validated at construction.
  */
-class Mass private constructor(magnitude: BigDecimal, prefix: Metric) :
-    Measure<Metric, Mass>(magnitude, prefix, SYMBOL, ::invoke) {
+class Mass internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+    Measure<Metric, Mass>(magnitude, prefix, SYMBOL, ::Mass) {
 
     companion object {
         /** The symbol for mass: "g" (gram). */
         private const val SYMBOL = "g"
-
-        /**
-         * Creates a new [Mass] quantity with the given [magnitude] and [prefix].
-         *
-         * The [magnitude] must be zero or positive. Negative mass is not permitted, as it represents a physically
-         * invalid state — mass can be absent (zero), but never less than zero.
-         *
-         * @param magnitude The numeric value of the mass.
-         * @param prefix The metric prefix to apply (e.g., m, k, M).
-         * @return A validated [Mass] instance.
-         * @throws NegativeMass if the magnitude is less than zero.
-         */
-        operator fun invoke(
-            magnitude: BigDecimal,
-            prefix: Metric = Metric.BASE,
-        ): Mass {
-            if (magnitude.negative) {
-                throw NegativeMass(magnitude, prefix, SYMBOL)
-            }
-            return Mass(magnitude, prefix)
-        }
     }
 }

--- a/lib/src/main/kotlin/org/kisu/units/base/Temperature.kt
+++ b/lib/src/main/kotlin/org/kisu/units/base/Temperature.kt
@@ -1,9 +1,7 @@
 package org.kisu.units.base
 
-import org.kisu.negative
 import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
-import org.kisu.units.exceptions.NegativeTemperature
 import java.math.BigDecimal
 
 /**
@@ -23,33 +21,11 @@ import java.math.BigDecimal
  * The magnitude is stored using [BigDecimal] for accuracy. All instances are validated to ensure they
  * respect physical constraints and are immutable once created.
  */
-class Temperature private constructor(magnitude: BigDecimal, prefix: Metric) :
-    Measure<Metric, Temperature>(magnitude, prefix, SYMBOL, ::invoke) {
+class Temperature internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+    Measure<Metric, Temperature>(magnitude, prefix, SYMBOL, ::Temperature) {
 
     companion object {
         /** The SI symbol for temperature: "K" (kelvin). */
         private const val SYMBOL = "K"
-
-        /**
-         * Creates a new [Temperature] quantity with the given [magnitude] and [prefix].
-         *
-         * The [magnitude] must be zero or positive. Negative temperatures are not permitted in kelvin,
-         * as they would represent values below absolute zero — a condition that is physically impossible
-         * in classical thermodynamics.
-         *
-         * @param magnitude The numeric value of the temperature.
-         * @param prefix The metric prefix to apply (e.g., m, k).
-         * @return A validated [Temperature] instance.
-         * @throws NegativeTemperature if the magnitude is less than zero.
-         */
-        operator fun invoke(
-            magnitude: BigDecimal,
-            prefix: Metric = Metric.BASE,
-        ): Temperature {
-            if (magnitude.negative) {
-                throw NegativeTemperature(magnitude, prefix, SYMBOL)
-            }
-            return Temperature(magnitude, prefix)
-        }
     }
 }

--- a/lib/src/main/kotlin/org/kisu/units/base/Time.kt
+++ b/lib/src/main/kotlin/org/kisu/units/base/Time.kt
@@ -1,9 +1,7 @@
 package org.kisu.units.base
 
-import org.kisu.negative
 import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
-import org.kisu.units.exceptions.NegativeTime
 import java.math.BigDecimal
 
 /**
@@ -20,32 +18,11 @@ import java.math.BigDecimal
  * The magnitude is stored using [BigDecimal] to ensure high precision. Instances of this class are immutable
  * and validated to reflect physical reality.
  */
-class Time private constructor(magnitude: BigDecimal, prefix: Metric) :
-    Measure<Metric, Time>(magnitude, prefix, SYMBOL, ::invoke) {
+class Time internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+    Measure<Metric, Time>(magnitude, prefix, SYMBOL, ::Time) {
 
     companion object {
         /** The SI symbol for time: "s" (second). */
         private const val SYMBOL = "s"
-
-        /**
-         * Creates a new [Time] quantity with the given [magnitude] and [prefix].
-         *
-         * The [magnitude] must be zero or positive. Negative time is not allowed because it would imply a
-         * backward duration, which is not valid when modeling time as an interval or duration.
-         *
-         * @param magnitude The numeric value of the time quantity.
-         * @param prefix The metric prefix to apply (e.g., m, µ, k).
-         * @return A validated [Time] instance.
-         * @throws NegativeTime if the magnitude is less than zero.
-         */
-        operator fun invoke(
-            magnitude: BigDecimal,
-            prefix: Metric = Metric.BASE,
-        ): Time {
-            if (magnitude.negative) {
-                throw NegativeTime(magnitude, prefix, SYMBOL)
-            }
-            return Time(magnitude, prefix)
-        }
     }
 }

--- a/lib/src/test/kotlin/org/kisu/units/base/AmountTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/base/AmountTest.kt
@@ -1,27 +1,18 @@
 package org.kisu.units.base
 
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.string.shouldStartWith
 import io.kotest.property.Arb
-import io.kotest.property.arbitrary.negativeLong
-import io.kotest.property.arbitrary.positiveLong
 import io.kotest.property.checkAll
 import org.kisu.bigDecimal
 import org.kisu.test.generators.MetricBuilders
+import org.kisu.test.generators.bigDecimal
 import org.kisu.units.builders.moles
-import org.kisu.units.exceptions.NegativeAmountOfSubstance
 
 class AmountTest : StringSpec({
 
-    "a negative amount is physically meaningless" {
-        checkAll(Arb.negativeLong(), MetricBuilders.generator) { magnitude, builder ->
-            shouldThrow<NegativeAmountOfSubstance> { magnitude.builder().moles }
-        }
-    }
-
-    "a positive amount constructs successfully" {
-        checkAll(Arb.positiveLong(), MetricBuilders.generator) { magnitude, builder ->
+    "creates an Amount" {
+        checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().moles
                 .representation shouldStartWith "${magnitude.bigDecimal} ${magnitude.builder().metric}"
         }

--- a/lib/src/test/kotlin/org/kisu/units/base/CurrentTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/base/CurrentTest.kt
@@ -3,16 +3,15 @@ package org.kisu.units.base
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.string.shouldStartWith
 import io.kotest.property.Arb
-import io.kotest.property.arbitrary.filter
-import io.kotest.property.arbitrary.long
 import io.kotest.property.checkAll
 import org.kisu.bigDecimal
 import org.kisu.test.generators.MetricBuilders
+import org.kisu.test.generators.bigDecimal
 import org.kisu.units.builders.amperes
 
 class CurrentTest : StringSpec({
-    "current creates successfully" {
-        checkAll(Arb.long().filter { it != 0L }, MetricBuilders.generator) { magnitude, builder ->
+    "creates a Current" {
+        checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().amperes
                 .representation shouldStartWith "${magnitude.bigDecimal} ${magnitude.builder().metric}"
         }

--- a/lib/src/test/kotlin/org/kisu/units/base/InformationTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/base/InformationTest.kt
@@ -5,24 +5,16 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.string.shouldStartWith
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.map
-import io.kotest.property.arbitrary.negativeLong
 import io.kotest.property.arbitrary.positiveLong
 import io.kotest.property.checkAll
 import org.kisu.bigDecimal
 import org.kisu.test.generators.BinaryBuilders
 import org.kisu.test.generators.bigDecimal
 import org.kisu.units.builders.bits
-import org.kisu.units.exceptions.NegativeInformation
 import org.kisu.units.exceptions.SubBitInformation
 import java.math.MathContext
 
 class InformationTest : StringSpec({
-    "negative information is physically meaningless" {
-        checkAll(Arb.negativeLong(), BinaryBuilders.generator) { magnitude, builder ->
-            shouldThrow<NegativeInformation> { magnitude.builder().bits }
-        }
-    }
-
     "fractional information is physically meaningless" {
         checkAll(
             Arb.bigDecimal(minFractionalDigits = 1).map { it.abs() },
@@ -33,7 +25,7 @@ class InformationTest : StringSpec({
         }
     }
 
-    "a positive and integer information constructs successfully" {
+    "creates Information" {
         checkAll(Arb.positiveLong(), BinaryBuilders.generator) { magnitude, builder ->
             magnitude.builder().bits
                 .representation shouldStartWith "${magnitude.bigDecimal} ${magnitude.builder().binary}"

--- a/lib/src/test/kotlin/org/kisu/units/base/LengthTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/base/LengthTest.kt
@@ -11,7 +11,7 @@ import org.kisu.test.generators.MetricBuilders
 import org.kisu.units.builders.meters
 
 class LengthTest : StringSpec({
-    "length creates successfully" {
+    "creates Length" {
         checkAll(Arb.long().filter { it != 0L }, MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().meters
                 .representation shouldStartWith "${magnitude.bigDecimal} ${magnitude.builder().metric}"

--- a/lib/src/test/kotlin/org/kisu/units/base/LuminousIntensityTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/base/LuminousIntensityTest.kt
@@ -1,25 +1,16 @@
 package org.kisu.units.base
 
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.string.shouldStartWith
 import io.kotest.property.Arb
-import io.kotest.property.arbitrary.negativeLong
 import io.kotest.property.arbitrary.positiveLong
 import io.kotest.property.checkAll
 import org.kisu.bigDecimal
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.units.builders.candelas
-import org.kisu.units.exceptions.NegativeLuminousIntensity
 
 class LuminousIntensityTest : StringSpec({
-    "a negative intensity is physically meaningless" {
-        checkAll(Arb.negativeLong(), MetricBuilders.generator) { magnitude, builder ->
-            shouldThrow<NegativeLuminousIntensity> { magnitude.builder().candelas }
-        }
-    }
-
-    "a positive intensity constructs successfully" {
+    "creates LuminousIntensity" {
         checkAll(Arb.positiveLong(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().candelas
                 .representation shouldStartWith "${magnitude.bigDecimal} ${magnitude.builder().metric}"

--- a/lib/src/test/kotlin/org/kisu/units/base/MassTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/base/MassTest.kt
@@ -1,26 +1,17 @@
 package org.kisu.units.base
 
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.string.shouldStartWith
 import io.kotest.property.Arb
-import io.kotest.property.arbitrary.negativeLong
-import io.kotest.property.arbitrary.positiveLong
 import io.kotest.property.checkAll
 import org.kisu.bigDecimal
 import org.kisu.test.generators.MetricBuilders
+import org.kisu.test.generators.bigDecimal
 import org.kisu.units.builders.grams
-import org.kisu.units.exceptions.NegativeMass
 
 class MassTest : StringSpec({
-    "a negative mass is physically meaningless" {
-        checkAll(Arb.negativeLong(), MetricBuilders.generator) { magnitude, builder ->
-            shouldThrow<NegativeMass> { magnitude.builder().grams }
-        }
-    }
-
-    "a positive mass constructs successfully" {
-        checkAll(Arb.positiveLong(), MetricBuilders.generator) { magnitude, builder ->
+    "creates mass" {
+        checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().grams
                 .representation shouldStartWith "${magnitude.bigDecimal} ${magnitude.builder().metric}"
         }

--- a/lib/src/test/kotlin/org/kisu/units/base/TemperatureTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/base/TemperatureTest.kt
@@ -1,26 +1,17 @@
 package org.kisu.units.base
 
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.string.shouldStartWith
 import io.kotest.property.Arb
-import io.kotest.property.arbitrary.negativeLong
-import io.kotest.property.arbitrary.positiveLong
 import io.kotest.property.checkAll
 import org.kisu.bigDecimal
 import org.kisu.test.generators.MetricBuilders
+import org.kisu.test.generators.bigDecimal
 import org.kisu.units.builders.kelvins
-import org.kisu.units.exceptions.NegativeTemperature
 
 class TemperatureTest : StringSpec({
-    "a negative temperature is physically meaningless" {
-        checkAll(Arb.negativeLong(), MetricBuilders.generator) { magnitude, builder ->
-            shouldThrow<NegativeTemperature> { magnitude.builder().kelvins }
-        }
-    }
-
-    "a positive temperature constructs successfully" {
-        checkAll(Arb.positiveLong(), MetricBuilders.generator) { magnitude, builder ->
+    "creates Temperature" {
+        checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().kelvins
                 .representation shouldStartWith "${magnitude.bigDecimal} ${magnitude.builder().metric}"
         }

--- a/lib/src/test/kotlin/org/kisu/units/base/TimeTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/base/TimeTest.kt
@@ -1,25 +1,16 @@
 package org.kisu.units.base
 
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.string.shouldStartWith
 import io.kotest.property.Arb
-import io.kotest.property.arbitrary.negativeLong
 import io.kotest.property.arbitrary.positiveLong
 import io.kotest.property.checkAll
 import org.kisu.bigDecimal
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.units.builders.seconds
-import org.kisu.units.exceptions.NegativeTime
 
 class TimeTest : StringSpec({
-    "a negative time is physically meaningless" {
-        checkAll(Arb.negativeLong(), MetricBuilders.generator) { magnitude, builder ->
-            shouldThrow<NegativeTime> { magnitude.builder().seconds }
-        }
-    }
-
-    "a positive time constructs successfully" {
+    "creates Time" {
         checkAll(Arb.positiveLong(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().seconds
                 .representation shouldStartWith "${magnitude.bigDecimal} ${magnitude.builder().metric}"


### PR DESCRIPTION
Closes #43 
  
## 🐞 Problem to Solve

This PR removes value validation logic from base unit constructors in KISU (e.g., disallowing negative values in Temperature), shifting responsibility for validation to explicit methods.

## 💡 Solution

Reverted all the constraints except for information where fractional bits still don't apply.

These constrainst will be reintroduced at a later date in a different way of safe units or similar.

---
  
  ✅ **Checklist**

- [X] The PR includes a clear and descriptive title
- [X] Related issue(s) are linked in the PR body
- [X] The solution is explained thoroughly
- [X] Tests or proofs are included

