### PR TITLE
Kisu 49 create expression system

### DIFF
--- a/lib/src/main/kotlin/org/kisu/Expressions.kt
+++ b/lib/src/main/kotlin/org/kisu/Expressions.kt
@@ -1,0 +1,26 @@
+package org.kisu
+
+import org.kisu.prefixes.Prefix
+import org.kisu.units.Expression
+import org.kisu.units.Product
+import org.kisu.units.Quotient
+import org.kisu.units.Scalar
+
+/**
+ * Returns a formatted representation of the expression's symbol, wrapping it in parentheses
+ * if the expression is a composite ([Product] or [Quotient]).
+ *
+ * This is useful for building nested unit expressions where operator precedence must be preserved.
+ * For example:
+ * - A scalar like `"kg"` returns `"kg"`.
+ * - A product like `"kg·K"` returns `"(kg·K)"`.
+ * - A quotient like `"J/(mol·K)"` returns `"(J/(mol·K))"`.
+ *
+ * This formatting ensures that symbols in larger compositions (e.g., `"(kg·K)/m²"`)
+ * are unambiguous and human-readable.
+ */
+val <A : Prefix<A>> Expression<A>.compositeRepresentation: String
+    get() = when (this) {
+        is Product<*, *>, is Quotient<*, *> -> "($symbol)"
+        is Scalar<*> -> symbol
+    }

--- a/lib/src/main/kotlin/org/kisu/prefixes/Binary.kt
+++ b/lib/src/main/kotlin/org/kisu/prefixes/Binary.kt
@@ -1,7 +1,7 @@
 package org.kisu.prefixes
 
+import org.kisu.prefixes.primitives.EnumSystem
 import org.kisu.prefixes.primitives.Representation
-import org.kisu.prefixes.primitives.StandardSystem
 import org.kisu.prefixes.primitives.Symbol
 import org.kisu.prefixes.primitives.System
 import java.math.BigDecimal
@@ -28,7 +28,7 @@ import java.math.BigDecimal
 enum class Binary(
     override val factor: BigDecimal,
     symbol: String,
-) : Prefix<Binary>, System<Binary> by StandardSystem(Binary::class), Symbol by Representation(symbol) {
+) : Prefix<Binary>, System<Binary> by EnumSystem(Binary::class), Symbol by Representation(symbol) {
     /** Base unit with factor 1 (2^0). */
     BASE(BigDecimal.ONE, ""),
 

--- a/lib/src/main/kotlin/org/kisu/prefixes/Decimal.kt
+++ b/lib/src/main/kotlin/org/kisu/prefixes/Decimal.kt
@@ -1,7 +1,7 @@
 package org.kisu.prefixes
 
+import org.kisu.prefixes.primitives.EnumSystem
 import org.kisu.prefixes.primitives.Representation
-import org.kisu.prefixes.primitives.StandardSystem
 import org.kisu.prefixes.primitives.Symbol
 import org.kisu.prefixes.primitives.System
 import java.math.BigDecimal
@@ -31,7 +31,7 @@ enum class Decimal(
     override val factor: BigDecimal,
     symbol: String,
 ) : Prefix<Decimal>,
-    System<Decimal> by StandardSystem(Decimal::class),
+    System<Decimal> by EnumSystem(Decimal::class),
     Symbol by Representation(symbol) {
     /** 1000⁰ = 1 */
     BASE(BigDecimal.ONE, ""),

--- a/lib/src/main/kotlin/org/kisu/prefixes/Metric.kt
+++ b/lib/src/main/kotlin/org/kisu/prefixes/Metric.kt
@@ -1,7 +1,7 @@
 package org.kisu.prefixes
 
+import org.kisu.prefixes.primitives.EnumSystem
 import org.kisu.prefixes.primitives.Representation
-import org.kisu.prefixes.primitives.StandardSystem
 import org.kisu.prefixes.primitives.Symbol
 import org.kisu.prefixes.primitives.System
 import java.math.BigDecimal
@@ -42,7 +42,7 @@ enum class Metric(
     override val factor: BigDecimal,
     symbol: String,
 ) : Prefix<Metric>,
-    System<Metric> by StandardSystem(Metric::class),
+    System<Metric> by EnumSystem(Metric::class),
     Symbol by Representation(symbol) {
     /** 10⁻³⁰ = 0.000000000000000000000000000001 */
     QUECTO(BigDecimal(BigInteger("1"), 30), "q"),

--- a/lib/src/main/kotlin/org/kisu/prefixes/primitives/CompositeSystem.kt
+++ b/lib/src/main/kotlin/org/kisu/prefixes/primitives/CompositeSystem.kt
@@ -1,0 +1,48 @@
+package org.kisu.prefixes.primitives
+
+import org.kisu.prefixes.Prefix
+import org.kisu.units.Product
+import org.kisu.units.Quotient
+
+/**
+ * Represents a composite [System] formed by combining two underlying prefix systems.
+ *
+ * This class models systems for composite expressions like [org.kisu.units.Product] and [org.kisu.units.Quotient],
+ * where each side (left and right) has its own prefix and system. It allows generating a full system of composite
+ * expressions by applying each prefix from the left-hand side to the right-hand component.
+ *
+ * For example, given two scalar systems:
+ * - Left: Metric prefixes with unit `"kg"`
+ * - Right: Metric prefixes with unit `"m"`
+ *
+ * You could create a composite system for `"kg·m"` or `"kg/m"` by combining each prefix from the left
+ * with the right-hand expression using the provided [create] function.
+ *
+ * @param T the resulting composite expression type (e.g., [Product], [Quotient]).
+ * @param A the type of the left-hand component (must be a [Prefix] and provide a [System]).
+ * @param B the type of the right-hand component (must be a [Prefix] and provide a [System]).
+ * @property a the left-hand expression instance, serving as the source for the prefix system on the left.
+ * @property b the right-hand expression instance, used as-is in all combinations.
+ * @property create a factory function used to construct the resulting composite expression from a pair of components.
+ */
+class CompositeSystem<T : Prefix<T>, A, B>(
+    private val a: A,
+    private val b: B,
+    private val create: (A, B) -> T
+) : System<T> where A : Prefix<A>, A : System<A>, B : Prefix<B>, B : System<B> {
+
+    override val canonical: T by lazy {
+        create(a.canonical, b.canonical)
+    }
+
+    override val all: List<T> by lazy {
+        a.all.map { prefix -> create(prefix, b) }.sorted()
+    }
+
+    override val smallest: T by lazy {
+        create(a.smallest, b)
+    }
+    override val largest: T by lazy {
+        create(a.largest, b)
+    }
+}

--- a/lib/src/main/kotlin/org/kisu/prefixes/primitives/EnumSystem.kt
+++ b/lib/src/main/kotlin/org/kisu/prefixes/primitives/EnumSystem.kt
@@ -7,7 +7,7 @@ import org.kisu.prefixes.Prefix
 import kotlin.reflect.KClass
 
 /**
- * A standard implementation of [System] that works with an enum class representing prefixes.
+ * A scalar implementation of [System] that works with an enum class representing prefixes.
  *
  * This class uses reflection on the provided enum class to:
  * - Retrieve all prefix values,
@@ -22,7 +22,7 @@ import kotlin.reflect.KClass
  *
  * @param klass The Kotlin class reference of the enum implementing [Prefix].
  */
-class StandardSystem<T : Prefix<T>>(klass: KClass<T>) : System<T> {
+class EnumSystem<T : Prefix<T>>(klass: KClass<T>) : System<T> {
     /**
      * The base prefix in the system, identified by power == 0.
      *

--- a/lib/src/main/kotlin/org/kisu/prefixes/primitives/ScalarSystem.kt
+++ b/lib/src/main/kotlin/org/kisu/prefixes/primitives/ScalarSystem.kt
@@ -1,0 +1,39 @@
+package org.kisu.prefixes.primitives
+
+import org.kisu.prefixes.Prefix
+import org.kisu.units.Scalar
+
+/**
+ * Represents a system of [Scalar] units derived from a given prefix system and unit symbol.
+ *
+ * This class adapts a [System] of prefixes (e.g., [Metric], [Binary]) into a system of full [Scalar] expressions,
+ * by pairing each prefix with a specific unit (e.g., `"m"` for meters, `"B"` for bytes).
+ *
+ * It provides the canonical, smallest, largest, and full list of all scalar variants derived from the prefix system.
+ * For example, if the prefix system is Metric and the unit is `"m"`, this system will generate:
+ * - `"nm"` (nano meter)
+ * - `"μm"` (micro meter)
+ * - `"m"` (meter, canonical)
+ * - `"km"` (kilometer)
+ * - etc.
+ *
+ * @param A the type of prefix used in the system, which must also provide a [System] implementation.
+ * @property prefix the base prefix instance (typically representing the current scalar).
+ * @property unit the unit symbol to which all prefixes are applied (e.g., "m", "B", "J").
+ */
+class ScalarSystem<A>(private val prefix: A, private val unit: String) :
+    System<Scalar<A>> where A : Prefix<A>, A : System<A> {
+    override val canonical: Scalar<A> by lazy {
+        Scalar(prefix.canonical, unit)
+    }
+    override val all: List<Scalar<A>> by lazy {
+        prefix.all.map { prefix -> Scalar(prefix, unit) }
+    }
+
+    override val smallest: Scalar<A> by lazy {
+        Scalar(prefix.smallest, unit)
+    }
+    override val largest: Scalar<A> by lazy {
+        Scalar(prefix.largest, unit)
+    }
+}

--- a/lib/src/main/kotlin/org/kisu/units/Expression.kt
+++ b/lib/src/main/kotlin/org/kisu/units/Expression.kt
@@ -1,0 +1,34 @@
+package org.kisu.units
+
+import org.kisu.prefixes.Prefix
+import org.kisu.prefixes.primitives.System
+
+/**
+ * Represents a combination of a [Prefix] and a unit symbol, forming a complete unit expression
+ * such as "km" (kilo + meter) or "μs" (micro + second).
+ *
+ * This class serves as the foundational abstraction for units with prefixes in a measurement system.
+ * It inherits from both [Prefix] and [System], ensuring that the expression behaves consistently
+ * within prefix and system operations.
+ *
+ * Equality is based on the unit symbol, meaning that two expressions are considered equal
+ * if they share the same symbol, regardless of their internal structure.
+ *
+ * @param A the type of prefix used in this expression.
+ */
+sealed class Expression<A : Prefix<A>> : Prefix<A>, System<A> {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Expression<*>
+
+        return symbol == other.symbol
+    }
+
+    override fun hashCode(): Int {
+        return symbol.hashCode()
+    }
+
+    override fun toString(): String = symbol
+}

--- a/lib/src/main/kotlin/org/kisu/units/Product.kt
+++ b/lib/src/main/kotlin/org/kisu/units/Product.kt
@@ -1,0 +1,38 @@
+package org.kisu.units
+
+import org.kisu.compositeRepresentation
+import org.kisu.prefixes.primitives.CompositeSystem
+import org.kisu.prefixes.primitives.System
+import java.math.BigDecimal
+
+/**
+ * Represents a composite [Expression] formed by the product of two other expressions,
+ * such as "N·m" (newton times meter) or "kg·m²" (kilogram times square meter).
+ *
+ * This class models multiplicative unit relationships, combining two expressions and
+ * delegating [System] behavior to a [CompositeSystem] that knows how to handle both sides.
+ *
+ * The resulting symbol is a dot-separated string of the left and right composite representations.
+ * If either side is itself a composite (e.g., a [Product] or [Quotient]), its representation is wrapped
+ * in parentheses to preserve grouping — e.g., "(kg·K)·m".
+ *
+ * @param A the type of the left-hand expression.
+ * @param B the type of the right-hand expression.
+ * @property left the left-hand component of the product.
+ * @property right the right-hand component of the product.
+ */
+class Product<A, B>(
+    private val left: A,
+    private val right: B
+) : Expression<Product<A, B>>(), System<Product<A, B>> by CompositeSystem(left, right, ::Product)
+    where A : Expression<A>, A : System<A>, B : Expression<B>, B : System<B> {
+
+    /** The combined factor of the product, equal to the product of the left and right factors. */
+    override val factor: BigDecimal by lazy { left.factor * right.factor }
+
+    /**
+     * The combined symbol, rendered as "left·right". If either operand is a composite expression,
+     * its representation will be wrapped in parentheses — e.g., "(kg·K)·m".
+     */
+    override val symbol: String by lazy { "${left.compositeRepresentation}·${right.compositeRepresentation}" }
+}

--- a/lib/src/main/kotlin/org/kisu/units/Quotient.kt
+++ b/lib/src/main/kotlin/org/kisu/units/Quotient.kt
@@ -1,0 +1,43 @@
+package org.kisu.units
+
+import org.kisu.KisuConfig
+import org.kisu.compositeRepresentation
+import org.kisu.prefixes.primitives.CompositeSystem
+import org.kisu.prefixes.primitives.System
+import java.math.BigDecimal
+
+/**
+ * Represents a composite [Expression] formed by the quotient of two other expressions,
+ * such as "m/s" (meter per second) or "J/(mol·K)" (joule per mole-kelvin).
+ *
+ * This class models divisive unit relationships, combining a numerator and a denominator,
+ * and delegates [System] behavior to a [CompositeSystem] that understands both sides.
+ *
+ * The resulting symbol is a slash-separated string of the numerator and denominator
+ * composite representations. If either side is itself a composite (e.g., a [Product] or [Quotient]),
+ * its representation is wrapped in parentheses to preserve grouping — e.g., "(kg·m)/(s²)".
+ *
+ * @param A the type of the numerator expression.
+ * @param B the type of the denominator expression.
+ * @property numerator the expression on the top of the quotient.
+ * @property denominator the expression on the bottom of the quotient.
+ */
+class Quotient<A, B>(
+    private val numerator: A,
+    private val denominator: B
+) : Expression<Quotient<A, B>>(), System<Quotient<A, B>> by CompositeSystem(numerator, denominator, ::Quotient)
+    where A : Expression<A>, A : System<A>, B : Expression<B>, B : System<B> {
+
+    /** The combined factor of the quotient, equal to numerator divided by denominator. */
+    override val factor: BigDecimal by lazy {
+        numerator.factor.divide(denominator.factor, KisuConfig.precision)
+    }
+
+    /**
+     * The combined symbol, rendered as "numerator/denominator". If either operand is a composite expression,
+     * its representation will be wrapped in parentheses — e.g., "W/(m·K)".
+     */
+    override val symbol: String by lazy {
+        "${numerator.compositeRepresentation}/${denominator.compositeRepresentation}"
+    }
+}

--- a/lib/src/main/kotlin/org/kisu/units/Scalar.kt
+++ b/lib/src/main/kotlin/org/kisu/units/Scalar.kt
@@ -1,0 +1,32 @@
+package org.kisu.units
+
+import org.kisu.prefixes.Prefix
+import org.kisu.prefixes.primitives.ScalarSystem
+import org.kisu.prefixes.primitives.System
+import java.math.BigDecimal
+
+/**
+ * Represents a scalar unit composed of a [Prefix] and a unit symbol, such as "km" (kilo + meter)
+ * or "μs" (micro + second).
+ *
+ * This is the base case of an [Expression], used to join together a prefix and a raw unit string,
+ * producing a complete symbol representation (e.g., "k" + "m" → "km").
+ *
+ * It delegates [System] behavior to a [ScalarSystem] composed of the same prefix and unit.
+ *
+ * @param A the type of prefix used in this scalar unit.
+ * @property prefix the prefix applied to the unit (e.g., kilo, milli).
+ * @property unit the symbol of the unit itself (e.g., "m" for meter).
+ */
+class Scalar<A>(
+    private val prefix: A,
+    private val unit: String
+) : Expression<Scalar<A>>(), System<Scalar<A>> by ScalarSystem(prefix, unit)
+    where A : Prefix<A>, A : System<A> {
+
+    /** The scaling factor of this scalar unit, delegated from the prefix. */
+    override val factor: BigDecimal = prefix.factor
+
+    /** The combined symbol of the prefix and unit (e.g., "km", "μs"). */
+    override val symbol: String by lazy { prefix.symbol + unit }
+}

--- a/lib/src/test/kotlin/org/kisu/prefixes/primitives/CompositeSystemTest.kt
+++ b/lib/src/test/kotlin/org/kisu/prefixes/primitives/CompositeSystemTest.kt
@@ -1,0 +1,59 @@
+package org.kisu.prefixes.primitives
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldBeSorted
+import io.kotest.matchers.shouldBe
+import io.kotest.property.checkAll
+import org.kisu.prefixes.Binary
+import org.kisu.prefixes.Metric
+import org.kisu.prefixes.isCanonical
+import org.kisu.test.fakes.FakeCompositePrefix
+import org.kisu.test.generators.Binaries
+import org.kisu.test.generators.Metrics
+
+class CompositeSystemTest : StringSpec({
+    "retrieves base unit" {
+        checkAll(Metrics.generator, Binaries.generator) { metric, binary ->
+            val (left, right) = createSystem(metric, binary).canonical
+
+            left.isCanonical.shouldBeTrue()
+            right.isCanonical.shouldBeTrue()
+        }
+    }
+
+    "retrieves all prefixes for a system" {
+        checkAll(Metrics.generator, Binaries.generator) { metric, binary ->
+            createSystem(metric, binary).all.forEach { (_, right) ->
+                right shouldBe binary
+            }
+        }
+    }
+
+    "all prefixes from a system are sorted by power" {
+        checkAll(Metrics.generator, Binaries.generator) { metric, binary ->
+            createSystem(metric, binary).all.shouldBeSorted()
+        }
+    }
+
+    "retrieves the smallest prefix" {
+        checkAll(Metrics.generator, Binaries.generator) { metric, binary ->
+            createSystem(metric, binary).smallest shouldBe createSystem(metric, binary).all.first()
+        }
+    }
+
+    "retrieves the largest prefix" {
+        checkAll(Metrics.generator, Binaries.generator) { metric, binary ->
+            createSystem(metric, binary).largest shouldBe createSystem(metric, binary).all.last()
+        }
+    }
+})
+
+private fun createSystem(
+    metric: Metric,
+    binary: Binary
+): CompositeSystem<FakeCompositePrefix<Metric, Binary>, Metric, Binary> = CompositeSystem(
+    metric,
+    binary,
+    { left: Metric, right: Binary -> FakeCompositePrefix(left, right) }
+)

--- a/lib/src/test/kotlin/org/kisu/prefixes/primitives/EnumSystemTest.kt
+++ b/lib/src/test/kotlin/org/kisu/prefixes/primitives/EnumSystemTest.kt
@@ -11,7 +11,7 @@ import org.kisu.one
 import org.kisu.test.fakes.InvalidPrefix
 import org.kisu.test.generators.Systems
 
-class SystemTest : StringSpec({
+class EnumSystemTest : StringSpec({
 
     "retrieves base unit" {
         checkAll(Systems.generator) { system ->
@@ -21,7 +21,7 @@ class SystemTest : StringSpec({
 
     "crashes if there is an invalid system with no base" {
         shouldThrow<IllegalStateException> {
-            StandardSystem(InvalidPrefix::class).canonical
+            EnumSystem(InvalidPrefix::class).canonical
         }
     }
 

--- a/lib/src/test/kotlin/org/kisu/prefixes/primitives/ScalarSystemTest.kt
+++ b/lib/src/test/kotlin/org/kisu/prefixes/primitives/ScalarSystemTest.kt
@@ -1,0 +1,49 @@
+package org.kisu.prefixes.primitives
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldBeSorted
+import io.kotest.matchers.collections.shouldContainInOrder
+import io.kotest.matchers.shouldBe
+import io.kotest.property.checkAll
+import org.kisu.one
+import org.kisu.test.fakes.TestUnit
+import org.kisu.test.generators.Metrics
+import org.kisu.units.Scalar
+
+class ScalarSystemTest : StringSpec({
+
+    "retrieves base unit" {
+        checkAll(Metrics.generator) { prefix ->
+            Scalar(prefix, TestUnit.SYMBOL).canonical.factor.one.shouldBeTrue()
+        }
+    }
+
+    "retrieves all prefixes for a system" {
+        checkAll(Metrics.generator) { prefix ->
+            Scalar(prefix, TestUnit.SYMBOL).all
+                .map { scalar -> scalar.factor }
+                .shouldContainInOrder(prefix.all.map { prefix -> prefix.factor })
+        }
+    }
+
+    "all prefixes from a system are sorted by power" {
+        checkAll(Metrics.generator) { prefix ->
+            Scalar(prefix, TestUnit.SYMBOL).all.shouldBeSorted()
+        }
+    }
+
+    "retrieves the smallest prefix" {
+        checkAll(Metrics.generator) { prefix ->
+            val scalar = Scalar(prefix, TestUnit.SYMBOL)
+            scalar.smallest shouldBe scalar.all.first()
+        }
+    }
+
+    "retrieves the largest prefix" {
+        checkAll(Metrics.generator) { prefix ->
+            val scalar = Scalar(prefix, TestUnit.SYMBOL)
+            scalar.largest shouldBe scalar.all.last()
+        }
+    }
+})

--- a/lib/src/test/kotlin/org/kisu/test/fakes/FakeCompositePrefix.kt
+++ b/lib/src/test/kotlin/org/kisu/test/fakes/FakeCompositePrefix.kt
@@ -1,0 +1,31 @@
+package org.kisu.test.fakes
+
+import org.kisu.prefixes.Prefix
+import org.kisu.prefixes.primitives.System
+import java.math.BigDecimal
+
+class FakeCompositePrefix<A, B>(
+    val a: A,
+    val b: B,
+) : Prefix<FakeCompositePrefix<A, B>>
+    where A : Prefix<A>, A : System<A>, B : Prefix<B>, B : System<B> {
+
+    override val factor: BigDecimal = a.factor + b.factor
+    override val symbol: String = a.symbol + "-" + b.symbol
+    override fun toString(): String = symbol
+    operator fun component1() = a
+    operator fun component2() = b
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as FakeCompositePrefix<*, *>
+
+        return symbol == other.symbol
+    }
+
+    override fun hashCode(): Int {
+        return symbol.hashCode()
+    }
+}

--- a/lib/src/test/kotlin/org/kisu/test/fakes/InvalidPrefix.kt
+++ b/lib/src/test/kotlin/org/kisu/test/fakes/InvalidPrefix.kt
@@ -1,8 +1,8 @@
 package org.kisu.test.fakes
 
 import org.kisu.prefixes.Prefix
+import org.kisu.prefixes.primitives.EnumSystem
 import org.kisu.prefixes.primitives.Representation
-import org.kisu.prefixes.primitives.StandardSystem
 import org.kisu.prefixes.primitives.Symbol
 import org.kisu.prefixes.primitives.System
 import java.math.BigDecimal
@@ -12,7 +12,7 @@ enum class InvalidPrefix(
     override val factor: BigDecimal,
     symbol: String,
 ) : Prefix<InvalidPrefix>,
-    System<InvalidPrefix> by StandardSystem(InvalidPrefix::class),
+    System<InvalidPrefix> by EnumSystem(InvalidPrefix::class),
     Symbol by Representation(symbol) {
     ERROR(BigDecimal("1000"), ""),
 }

--- a/lib/src/test/kotlin/org/kisu/test/generators/Binaries.kt
+++ b/lib/src/test/kotlin/org/kisu/test/generators/Binaries.kt
@@ -3,8 +3,8 @@ package org.kisu.test.generators
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.of
 import org.kisu.prefixes.Binary
-import org.kisu.prefixes.primitives.StandardSystem
+import org.kisu.prefixes.primitives.EnumSystem
 
 object Binaries : Generator<Binary> {
-    override val generator: Arb<Binary> = Arb.of(StandardSystem(Binary::class).all)
+    override val generator: Arb<Binary> = Arb.of(EnumSystem(Binary::class).all)
 }

--- a/lib/src/test/kotlin/org/kisu/test/generators/Decimals.kt
+++ b/lib/src/test/kotlin/org/kisu/test/generators/Decimals.kt
@@ -3,8 +3,8 @@ package org.kisu.test.generators
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.of
 import org.kisu.prefixes.Decimal
-import org.kisu.prefixes.primitives.StandardSystem
+import org.kisu.prefixes.primitives.EnumSystem
 
 object Decimals : Generator<Decimal> {
-    override val generator: Arb<Decimal> = Arb.of(StandardSystem(Decimal::class).all)
+    override val generator: Arb<Decimal> = Arb.of(EnumSystem(Decimal::class).all)
 }

--- a/lib/src/test/kotlin/org/kisu/test/generators/Metrics.kt
+++ b/lib/src/test/kotlin/org/kisu/test/generators/Metrics.kt
@@ -3,8 +3,8 @@ package org.kisu.test.generators
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.of
 import org.kisu.prefixes.Metric
-import org.kisu.prefixes.primitives.StandardSystem
+import org.kisu.prefixes.primitives.EnumSystem
 
 object Metrics : Generator<Metric> {
-    override val generator: Arb<Metric> = Arb.of(StandardSystem(Metric::class).all)
+    override val generator: Arb<Metric> = Arb.of(EnumSystem(Metric::class).all)
 }

--- a/lib/src/test/kotlin/org/kisu/test/generators/Systems.kt
+++ b/lib/src/test/kotlin/org/kisu/test/generators/Systems.kt
@@ -5,13 +5,13 @@ import io.kotest.property.arbitrary.of
 import org.kisu.prefixes.Binary
 import org.kisu.prefixes.Decimal
 import org.kisu.prefixes.Metric
-import org.kisu.prefixes.primitives.StandardSystem
+import org.kisu.prefixes.primitives.EnumSystem
 
-object Systems : Generator<StandardSystem<*>> {
-    override val generator: Arb<StandardSystem<*>> =
+object Systems : Generator<EnumSystem<*>> {
+    override val generator: Arb<EnumSystem<*>> =
         Arb.of(
-            StandardSystem(Metric::class),
-            StandardSystem(Binary::class),
-            StandardSystem(Decimal::class),
+            EnumSystem(Metric::class),
+            EnumSystem(Binary::class),
+            EnumSystem(Decimal::class),
         )
 }

--- a/lib/src/test/kotlin/org/kisu/units/ExpressionTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/ExpressionTest.kt
@@ -1,0 +1,60 @@
+package org.kisu.units
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+import io.kotest.property.checkAll
+import org.kisu.test.fakes.TestUnit
+import org.kisu.test.generators.Binaries
+import org.kisu.test.generators.Metrics
+
+class ExpressionTest : StringSpec({
+    "the string representation is the symbol" {
+        checkAll(Metrics.generator, Binaries.generator) { metric, binary ->
+            val expression = Quotient(
+                Scalar(metric, TestUnit.SYMBOL),
+                Scalar(binary, TestUnit.SYMBOL)
+            )
+            expression.symbol shouldBe expression.toString()
+        }
+    }
+
+    "equality is reflexive" {
+        checkAll(Metrics.generator) { metric ->
+            val x = Scalar(metric, TestUnit.SYMBOL)
+
+            (x == x).shouldBeTrue()
+        }
+    }
+
+    "equality is symmetric" {
+        checkAll(Metrics.generator) { metric ->
+            val x = Scalar(metric, TestUnit.SYMBOL)
+            val y = Scalar(metric, TestUnit.SYMBOL)
+
+            (x == y) shouldBe (y == x)
+        }
+    }
+
+    "equality is transitive" {
+        checkAll(Metrics.generator) { metric ->
+            val x = Scalar(metric, TestUnit.SYMBOL)
+            val y = Scalar(metric, TestUnit.SYMBOL)
+            val z = Scalar(metric, TestUnit.SYMBOL)
+
+            (x == y).shouldBeTrue()
+            (y == z).shouldBeTrue()
+            (x == z).shouldBeTrue()
+        }
+    }
+
+    @Suppress("EqualsNullCall")
+    "equality is non-null" {
+        checkAll(Metrics.generator) { metric ->
+            val x = Scalar(metric, TestUnit.SYMBOL)
+
+            (x.equals(null)).shouldBeFalse()
+        }
+    }
+})

--- a/lib/src/test/kotlin/org/kisu/units/ProductTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/ProductTest.kt
@@ -1,0 +1,40 @@
+package org.kisu.units
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.checkAll
+import org.kisu.test.fakes.TestUnit
+import org.kisu.test.generators.Binaries
+import org.kisu.test.generators.Metrics
+
+class ProductTest : StringSpec({
+    "factor is the product of both prefixes" {
+        checkAll(Metrics.generator, Binaries.generator) { metric, binary ->
+            val expression = Product(
+                Scalar(metric, TestUnit.SYMBOL),
+                Scalar(binary, TestUnit.SYMBOL)
+            )
+
+            expression.factor shouldBe metric.factor * binary.factor
+        }
+    }
+
+    "represents its symbol" {
+        checkAll(Metrics.generator, Binaries.generator) { metric, binary ->
+            Product(
+                Scalar(metric, TestUnit.SYMBOL),
+                Scalar(binary, TestUnit.SYMBOL)
+            ).symbol shouldBe "${metric.symbol}${TestUnit.SYMBOL}·${binary.symbol}${TestUnit.SYMBOL}"
+        }
+    }
+
+    "the string representation is the symbol" {
+        checkAll(Metrics.generator, Binaries.generator) { metric, binary ->
+            val expression = Product(
+                Scalar(metric, TestUnit.SYMBOL),
+                Scalar(binary, TestUnit.SYMBOL)
+            )
+            expression.symbol shouldBe expression.toString()
+        }
+    }
+})

--- a/lib/src/test/kotlin/org/kisu/units/QuotientTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/QuotientTest.kt
@@ -1,0 +1,41 @@
+package org.kisu.units
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.checkAll
+import org.kisu.KisuConfig
+import org.kisu.test.fakes.TestUnit
+import org.kisu.test.generators.Binaries
+import org.kisu.test.generators.Metrics
+
+class QuotientTest : StringSpec({
+    "factor is the quotient of both prefixes" {
+        checkAll(Metrics.generator, Binaries.generator) { metric, binary ->
+            val expression = Quotient(
+                Scalar(metric, TestUnit.SYMBOL),
+                Scalar(binary, TestUnit.SYMBOL)
+            )
+
+            expression.factor shouldBe metric.factor.divide(binary.factor, KisuConfig.precision)
+        }
+    }
+
+    "represents its symbol" {
+        checkAll(Metrics.generator, Binaries.generator) { metric, binary ->
+            Quotient(
+                Scalar(metric, TestUnit.SYMBOL),
+                Scalar(binary, TestUnit.SYMBOL)
+            ).symbol shouldBe "${metric.symbol}${TestUnit.SYMBOL}/${binary.symbol}${TestUnit.SYMBOL}"
+        }
+    }
+
+    "the string representation is the symbol" {
+        checkAll(Metrics.generator, Binaries.generator) { metric, binary ->
+            val expression = Quotient(
+                Scalar(metric, TestUnit.SYMBOL),
+                Scalar(binary, TestUnit.SYMBOL)
+            )
+            expression.symbol shouldBe expression.toString()
+        }
+    }
+})

--- a/lib/src/test/kotlin/org/kisu/units/ScalarTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/ScalarTest.kt
@@ -1,0 +1,28 @@
+package org.kisu.units
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.checkAll
+import org.kisu.test.fakes.TestUnit
+import org.kisu.test.generators.Metrics
+
+class ScalarTest : StringSpec({
+    "delegates factor to the prefix" {
+        checkAll(Metrics.generator) { metric ->
+            Scalar(metric, TestUnit.SYMBOL).factor shouldBe metric.factor
+        }
+    }
+
+    "symbol is the combination of the prefix and the unit" {
+        checkAll(Metrics.generator) { metric ->
+            Scalar(metric, TestUnit.SYMBOL).symbol shouldBe "${metric.symbol}${TestUnit.SYMBOL}"
+        }
+    }
+
+    "the string representation is the symbol" {
+        checkAll(Metrics.generator) { metric ->
+            val expression = Scalar(metric, TestUnit.SYMBOL)
+            expression.symbol shouldBe expression.toString()
+        }
+    }
+})


### PR DESCRIPTION
## 🐞 Problem to Solve

Until now, the KISU library represented unit scaling using Prefix and System interfaces, enabling clean abstraction of metric and binary scaling factors (e.g., kilo, milli, mebi, etc.). While this system worked well for simple scalars (e.g., km, MiB), it lacked the necessary expressiveness to:

- **Represent composite units** such as kW/(m·K) or MJ/kg·K
- **Cleanly combine and format prefix + unit** symbol together
- Support **recursive composition of prefixed units**, with structured printing and scaling logic

## 💡 Solution

This PR introduces a new `Expression<A> `class hierarchy that models unit expressions — pairing a prefix (e.g. kilo) with a unit symbol (e.g. "W"), and composing them into products and quotients.

The new structure includes:

- `Scalar<A>:` a leaf node representing a single prefixed unit, e.g., kW
- `Product<A, B>`: a composition of two expressions using multiplication (e.g. N·m)
- `Quotient<A, B>`: a composition using division (e.g. W/m²)- 

All of these implement `Prefix<T>` and `System<T>`, allowing them to plug naturally into the existing measure system, and expose:

- `factor`: BigDecimal representing the total scaling factor
- `symbol`: String representing the display-friendly representation (e.g., kW/m·K)
- Delegated comparison and conversion behavior via the Prefix contract

**Benefits**
- **Enables display-ready symbolic representation of complex units**
- **Supports recursive composition** of units (e.g., kJ/(kg·K))
- **Makes rescaling and conversion of complex units possible** using the existing Prefix infrastructure
- **Retains compatibility with the existing `System<A>` design**
- **Paves the way for simplifying and unifying** how units are printed, composed, and handled across scalar and derived types

**Future work:**
- Integrate expression logic into `Measure` to allow full symbolic and computational interoperability

---
  
  ✅ **Checklist**

- [X] The PR includes a clear and descriptive title
- [X] Related issue(s) are linked in the PR body
- [X] The solution is explained thoroughly
- [X] Tests or proofs are included

