### PR TITLE
[KISU-49] Changes second component to return the Expression

### DIFF
--- a/lib/src/main/kotlin/org/kisu/units/Measure.kt
+++ b/lib/src/main/kotlin/org/kisu/units/Measure.kt
@@ -271,7 +271,7 @@ abstract class Measure<A, Self : Measure<A, Self>> protected constructor(
      * val (_, expression, _) = measure
      * ```
      */
-    operator fun component2(): String = expression.symbol
+    operator fun component2(): A = expression
 
     /**
      * Returns the unit name of this measure.

--- a/lib/src/test/kotlin/org/kisu/units/MeasureTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/MeasureTest.kt
@@ -318,7 +318,7 @@ class MeasureTest : StringSpec({
         checkAll(Arb.bigDecimal(), MetricGenerator.generator) { magnitude, prefix ->
             TestUnit(magnitude, prefix).should { (number, expression, unit) ->
                 number shouldBe magnitude
-                expression shouldBe "$prefix${TestUnit.SYMBOL}"
+                expression shouldBe Scalar(prefix, TestUnit.SYMBOL)
                 unit shouldBe TestUnit.SYMBOL
             }
         }

--- a/lib/src/test/kotlin/org/kisu/units/base/AmountTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/base/AmountTest.kt
@@ -5,8 +5,10 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.checkAll
+import org.kisu.prefixes.Metric
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
+import org.kisu.units.Scalar
 import org.kisu.units.builders.moles
 
 class AmountTest : StringSpec({
@@ -15,7 +17,7 @@ class AmountTest : StringSpec({
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().moles.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe "${magnitude.builder().metric.symbol}${Amount.SYMBOL}"
+                expression shouldBe Scalar(magnitude.builder().metric, Amount.SYMBOL)
                 symbol shouldBe Amount.SYMBOL
             }
         }
@@ -25,7 +27,7 @@ class AmountTest : StringSpec({
         checkAll(Arb.bigDecimal()) { magnitude ->
             magnitude.moles.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe Amount.SYMBOL
+                expression shouldBe Scalar(Metric.BASE, Amount.SYMBOL)
                 symbol shouldBe Amount.SYMBOL
             }
         }

--- a/lib/src/test/kotlin/org/kisu/units/base/CurrentTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/base/CurrentTest.kt
@@ -5,8 +5,10 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.checkAll
+import org.kisu.prefixes.Metric
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
+import org.kisu.units.Scalar
 import org.kisu.units.builders.amperes
 
 class CurrentTest : StringSpec({
@@ -14,7 +16,7 @@ class CurrentTest : StringSpec({
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().amperes.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe "${magnitude.builder().metric.symbol}${Current.SYMBOL}"
+                expression shouldBe Scalar(magnitude.builder().metric, Current.SYMBOL)
                 symbol shouldBe Current.SYMBOL
             }
         }
@@ -24,7 +26,7 @@ class CurrentTest : StringSpec({
         checkAll(Arb.bigDecimal()) { magnitude ->
             magnitude.amperes.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe Current.SYMBOL
+                expression shouldBe Scalar(Metric.BASE, Current.SYMBOL)
                 symbol shouldBe Current.SYMBOL
             }
         }

--- a/lib/src/test/kotlin/org/kisu/units/base/InformationTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/base/InformationTest.kt
@@ -9,8 +9,10 @@ import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.positiveLong
 import io.kotest.property.checkAll
 import org.kisu.bigDecimal
+import org.kisu.prefixes.Binary
 import org.kisu.test.generators.BinaryBuilders
 import org.kisu.test.generators.bigDecimal
+import org.kisu.units.Scalar
 import org.kisu.units.builders.bits
 import org.kisu.units.exceptions.SubBitInformation
 import java.math.MathContext
@@ -30,7 +32,7 @@ class InformationTest : StringSpec({
         checkAll(Arb.positiveLong(), BinaryBuilders.generator) { magnitude, builder ->
             magnitude.builder().bits.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude.bigDecimal
-                expression shouldBe "${magnitude.builder().binary.symbol}${Information.SYMBOL}"
+                expression shouldBe Scalar(magnitude.builder().binary, Information.SYMBOL)
                 symbol shouldBe Information.SYMBOL
             }
         }
@@ -40,7 +42,7 @@ class InformationTest : StringSpec({
         checkAll(Arb.positiveLong()) { magnitude ->
             magnitude.bits.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude.bigDecimal
-                expression shouldBe Information.SYMBOL
+                expression shouldBe Scalar(Binary.BASE, Information.SYMBOL)
                 symbol shouldBe Information.SYMBOL
             }
         }

--- a/lib/src/test/kotlin/org/kisu/units/base/LengthTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/base/LengthTest.kt
@@ -8,8 +8,10 @@ import io.kotest.property.arbitrary.filter
 import io.kotest.property.arbitrary.long
 import io.kotest.property.checkAll
 import org.kisu.bigDecimal
+import org.kisu.prefixes.Metric
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
+import org.kisu.units.Scalar
 import org.kisu.units.builders.meters
 
 class LengthTest : StringSpec({
@@ -17,7 +19,7 @@ class LengthTest : StringSpec({
         checkAll(Arb.long().filter { it != 0L }, MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().meters.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude.bigDecimal
-                expression shouldBe "${magnitude.builder().metric.symbol}${Length.SYMBOL}"
+                expression shouldBe Scalar(magnitude.builder().metric, Length.SYMBOL)
                 symbol shouldBe Length.SYMBOL
             }
         }
@@ -27,7 +29,7 @@ class LengthTest : StringSpec({
         checkAll(Arb.bigDecimal()) { magnitude ->
             magnitude.meters.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude.bigDecimal
-                expression shouldBe Length.SYMBOL
+                expression shouldBe Scalar(Metric.BASE, Length.SYMBOL)
                 symbol shouldBe Length.SYMBOL
             }
         }

--- a/lib/src/test/kotlin/org/kisu/units/base/LuminousIntensityTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/base/LuminousIntensityTest.kt
@@ -7,8 +7,10 @@ import io.kotest.property.Arb
 import io.kotest.property.arbitrary.positiveLong
 import io.kotest.property.checkAll
 import org.kisu.bigDecimal
+import org.kisu.prefixes.Metric
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
+import org.kisu.units.Scalar
 import org.kisu.units.builders.candelas
 
 class LuminousIntensityTest : StringSpec({
@@ -16,7 +18,7 @@ class LuminousIntensityTest : StringSpec({
         checkAll(Arb.positiveLong(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().candelas.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude.bigDecimal
-                expression shouldBe "${magnitude.builder().metric.symbol}${LuminousIntensity.SYMBOL}"
+                expression shouldBe Scalar(magnitude.builder().metric, LuminousIntensity.SYMBOL)
                 symbol shouldBe LuminousIntensity.SYMBOL
             }
         }
@@ -26,7 +28,7 @@ class LuminousIntensityTest : StringSpec({
         checkAll(Arb.bigDecimal()) { magnitude ->
             magnitude.candelas.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude.bigDecimal
-                expression shouldBe LuminousIntensity.SYMBOL
+                expression shouldBe Scalar(Metric.BASE, LuminousIntensity.SYMBOL)
                 symbol shouldBe LuminousIntensity.SYMBOL
             }
         }

--- a/lib/src/test/kotlin/org/kisu/units/base/MassTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/base/MassTest.kt
@@ -5,8 +5,10 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.checkAll
+import org.kisu.prefixes.Metric
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
+import org.kisu.units.Scalar
 import org.kisu.units.builders.grams
 
 class MassTest : StringSpec({
@@ -14,7 +16,7 @@ class MassTest : StringSpec({
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().grams.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe "${magnitude.builder().metric.symbol}${Mass.SYMBOL}"
+                expression shouldBe Scalar(magnitude.builder().metric, Mass.SYMBOL)
                 symbol shouldBe Mass.SYMBOL
             }
         }
@@ -24,7 +26,7 @@ class MassTest : StringSpec({
         checkAll(Arb.bigDecimal()) { magnitude ->
             magnitude.grams.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe Mass.SYMBOL
+                expression shouldBe Scalar(Metric.BASE, Mass.SYMBOL)
                 symbol shouldBe Mass.SYMBOL
             }
         }

--- a/lib/src/test/kotlin/org/kisu/units/base/TemperatureTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/base/TemperatureTest.kt
@@ -5,8 +5,10 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.checkAll
+import org.kisu.prefixes.Metric
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
+import org.kisu.units.Scalar
 import org.kisu.units.builders.kelvins
 
 class TemperatureTest : StringSpec({
@@ -14,7 +16,7 @@ class TemperatureTest : StringSpec({
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().kelvins.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe "${magnitude.builder().metric.symbol}${Temperature.SYMBOL}"
+                expression shouldBe Scalar(magnitude.builder().metric, Temperature.SYMBOL)
                 symbol shouldBe Temperature.SYMBOL
             }
         }
@@ -24,7 +26,7 @@ class TemperatureTest : StringSpec({
         checkAll(Arb.bigDecimal()) { magnitude ->
             magnitude.kelvins.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe Temperature.SYMBOL
+                expression shouldBe Scalar(Metric.BASE, Temperature.SYMBOL)
                 symbol shouldBe Temperature.SYMBOL
             }
         }

--- a/lib/src/test/kotlin/org/kisu/units/base/TimeTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/base/TimeTest.kt
@@ -7,8 +7,10 @@ import io.kotest.property.Arb
 import io.kotest.property.arbitrary.positiveLong
 import io.kotest.property.checkAll
 import org.kisu.bigDecimal
+import org.kisu.prefixes.Metric
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
+import org.kisu.units.Scalar
 import org.kisu.units.builders.seconds
 
 class TimeTest : StringSpec({
@@ -16,7 +18,7 @@ class TimeTest : StringSpec({
         checkAll(Arb.positiveLong(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().seconds.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude.bigDecimal
-                expression shouldBe "${magnitude.builder().metric.symbol}${Time.SYMBOL}"
+                expression shouldBe Scalar(magnitude.builder().metric, Time.SYMBOL)
                 symbol shouldBe Time.SYMBOL
             }
         }
@@ -26,7 +28,7 @@ class TimeTest : StringSpec({
         checkAll(Arb.bigDecimal()) { magnitude ->
             magnitude.seconds.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude.bigDecimal
-                expression shouldBe Time.SYMBOL
+                expression shouldBe Scalar(Metric.BASE, Time.SYMBOL)
                 symbol shouldBe Time.SYMBOL
             }
         }

--- a/lib/src/test/kotlin/org/kisu/units/derived/AbsorbedDoseTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/derived/AbsorbedDoseTest.kt
@@ -5,8 +5,10 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.checkAll
+import org.kisu.prefixes.Metric
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
+import org.kisu.units.Scalar
 import org.kisu.units.builders.grays
 
 class AbsorbedDoseTest : StringSpec({
@@ -15,7 +17,7 @@ class AbsorbedDoseTest : StringSpec({
             magnitude.builder().grays
                 .should { (amount, expression, symbol) ->
                     amount shouldBe magnitude
-                    expression shouldBe "${magnitude.builder().metric.symbol}${AbsorbedDose.SYMBOL}"
+                    expression shouldBe Scalar(magnitude.builder().metric, AbsorbedDose.SYMBOL)
                     symbol shouldBe AbsorbedDose.SYMBOL
                 }
         }
@@ -25,7 +27,7 @@ class AbsorbedDoseTest : StringSpec({
         checkAll(Arb.bigDecimal()) { magnitude ->
             magnitude.grays.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe AbsorbedDose.SYMBOL
+                expression shouldBe Scalar(Metric.BASE, AbsorbedDose.SYMBOL)
                 symbol shouldBe AbsorbedDose.SYMBOL
             }
         }

--- a/lib/src/test/kotlin/org/kisu/units/derived/AreaTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/derived/AreaTest.kt
@@ -5,8 +5,10 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.checkAll
+import org.kisu.prefixes.Metric
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
+import org.kisu.units.Scalar
 import org.kisu.units.builders.squareMeters
 
 class AreaTest : StringSpec({
@@ -14,7 +16,7 @@ class AreaTest : StringSpec({
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().squareMeters.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe "${magnitude.builder().metric.symbol}${Area.SYMBOL}"
+                expression shouldBe Scalar(magnitude.builder().metric, Area.SYMBOL)
                 symbol shouldBe Area.SYMBOL
             }
         }
@@ -24,7 +26,7 @@ class AreaTest : StringSpec({
         checkAll(Arb.bigDecimal()) { magnitude ->
             magnitude.squareMeters.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe Area.SYMBOL
+                expression shouldBe Scalar(Metric.BASE, Area.SYMBOL)
                 symbol shouldBe Area.SYMBOL
             }
         }

--- a/lib/src/test/kotlin/org/kisu/units/derived/ByteTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/derived/ByteTest.kt
@@ -5,8 +5,10 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.checkAll
+import org.kisu.prefixes.Metric
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
+import org.kisu.units.Scalar
 import org.kisu.units.builders.bytes
 
 class ByteTest : StringSpec({
@@ -14,7 +16,7 @@ class ByteTest : StringSpec({
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().bytes.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe "${magnitude.builder().metric.symbol}${Byte.SYMBOL}"
+                expression shouldBe Scalar(magnitude.builder().metric, Byte.SYMBOL)
                 symbol shouldBe Byte.SYMBOL
             }
         }
@@ -24,7 +26,7 @@ class ByteTest : StringSpec({
         checkAll(Arb.bigDecimal()) { magnitude ->
             magnitude.bytes.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe Byte.SYMBOL
+                expression shouldBe Scalar(Metric.BASE, Byte.SYMBOL)
                 symbol shouldBe Byte.SYMBOL
             }
         }

--- a/lib/src/test/kotlin/org/kisu/units/derived/CapacitanceTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/derived/CapacitanceTest.kt
@@ -5,8 +5,10 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.checkAll
+import org.kisu.prefixes.Metric
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
+import org.kisu.units.Scalar
 import org.kisu.units.builders.farads
 
 class CapacitanceTest : StringSpec({
@@ -14,7 +16,7 @@ class CapacitanceTest : StringSpec({
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().farads.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe "${magnitude.builder().metric.symbol}${Capacitance.SYMBOL}"
+                expression shouldBe Scalar(magnitude.builder().metric, Capacitance.SYMBOL)
                 symbol shouldBe Capacitance.SYMBOL
             }
         }
@@ -24,7 +26,7 @@ class CapacitanceTest : StringSpec({
         checkAll(Arb.bigDecimal()) { magnitude ->
             magnitude.farads.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe Capacitance.SYMBOL
+                expression shouldBe Scalar(Metric.BASE, Capacitance.SYMBOL)
                 symbol shouldBe Capacitance.SYMBOL
             }
         }

--- a/lib/src/test/kotlin/org/kisu/units/derived/CatalyticActivityTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/derived/CatalyticActivityTest.kt
@@ -5,8 +5,10 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.checkAll
+import org.kisu.prefixes.Metric
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
+import org.kisu.units.Scalar
 import org.kisu.units.builders.katals
 
 class CatalyticActivityTest : StringSpec({
@@ -14,7 +16,7 @@ class CatalyticActivityTest : StringSpec({
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().katals.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe "${magnitude.builder().metric.symbol}${CatalyticActivity.SYMBOL}"
+                expression shouldBe Scalar(magnitude.builder().metric, CatalyticActivity.SYMBOL)
                 symbol shouldBe CatalyticActivity.SYMBOL
             }
         }
@@ -24,7 +26,7 @@ class CatalyticActivityTest : StringSpec({
         checkAll(Arb.bigDecimal()) { magnitude ->
             magnitude.katals.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe CatalyticActivity.SYMBOL
+                expression shouldBe Scalar(Metric.BASE, CatalyticActivity.SYMBOL)
                 symbol shouldBe CatalyticActivity.SYMBOL
             }
         }

--- a/lib/src/test/kotlin/org/kisu/units/derived/CelsiusTemperatureTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/derived/CelsiusTemperatureTest.kt
@@ -5,8 +5,10 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.checkAll
+import org.kisu.prefixes.Metric
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
+import org.kisu.units.Scalar
 import org.kisu.units.builders.celsius
 
 class CelsiusTemperatureTest : StringSpec({
@@ -14,7 +16,7 @@ class CelsiusTemperatureTest : StringSpec({
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().celsius.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe "${magnitude.builder().metric.symbol}${Celsius.SYMBOL}"
+                expression shouldBe Scalar(magnitude.builder().metric, Celsius.SYMBOL)
                 symbol shouldBe Celsius.SYMBOL
             }
         }
@@ -24,7 +26,7 @@ class CelsiusTemperatureTest : StringSpec({
         checkAll(Arb.bigDecimal()) { magnitude ->
             magnitude.celsius.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe Celsius.SYMBOL
+                expression shouldBe Scalar(Metric.BASE, Celsius.SYMBOL)
                 symbol shouldBe Celsius.SYMBOL
             }
         }

--- a/lib/src/test/kotlin/org/kisu/units/derived/ConductanceTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/derived/ConductanceTest.kt
@@ -5,8 +5,10 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.checkAll
+import org.kisu.prefixes.Metric
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
+import org.kisu.units.Scalar
 import org.kisu.units.builders.siemens
 
 class ConductanceTest : StringSpec({
@@ -14,7 +16,7 @@ class ConductanceTest : StringSpec({
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().siemens.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe "${magnitude.builder().metric.symbol}${Conductance.SYMBOL}"
+                expression shouldBe Scalar(magnitude.builder().metric, Conductance.SYMBOL)
                 symbol shouldBe Conductance.SYMBOL
             }
         }
@@ -24,7 +26,7 @@ class ConductanceTest : StringSpec({
         checkAll(Arb.bigDecimal()) { magnitude ->
             magnitude.siemens.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe Conductance.SYMBOL
+                expression shouldBe Scalar(Metric.BASE, Conductance.SYMBOL)
                 symbol shouldBe Conductance.SYMBOL
             }
         }

--- a/lib/src/test/kotlin/org/kisu/units/derived/DoseEquivalentTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/derived/DoseEquivalentTest.kt
@@ -5,8 +5,10 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.checkAll
+import org.kisu.prefixes.Metric
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
+import org.kisu.units.Scalar
 import org.kisu.units.builders.sieverts
 
 class DoseEquivalentTest : StringSpec({
@@ -14,7 +16,7 @@ class DoseEquivalentTest : StringSpec({
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().sieverts.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe "${magnitude.builder().metric.symbol}${DoseEquivalent.SYMBOL}"
+                expression shouldBe Scalar(magnitude.builder().metric, DoseEquivalent.SYMBOL)
                 symbol shouldBe DoseEquivalent.SYMBOL
             }
         }
@@ -24,7 +26,7 @@ class DoseEquivalentTest : StringSpec({
         checkAll(Arb.bigDecimal()) { magnitude ->
             magnitude.sieverts.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe DoseEquivalent.SYMBOL
+                expression shouldBe Scalar(Metric.BASE, DoseEquivalent.SYMBOL)
                 symbol shouldBe DoseEquivalent.SYMBOL
             }
         }

--- a/lib/src/test/kotlin/org/kisu/units/derived/ElectricChargeTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/derived/ElectricChargeTest.kt
@@ -5,8 +5,10 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.checkAll
+import org.kisu.prefixes.Metric
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
+import org.kisu.units.Scalar
 import org.kisu.units.builders.coulombs
 
 class ElectricChargeTest : StringSpec({
@@ -14,7 +16,7 @@ class ElectricChargeTest : StringSpec({
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().coulombs.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe "${magnitude.builder().metric.symbol}${ElectricCharge.SYMBOL}"
+                expression shouldBe Scalar(magnitude.builder().metric, ElectricCharge.SYMBOL)
                 symbol shouldBe ElectricCharge.SYMBOL
             }
         }
@@ -24,7 +26,7 @@ class ElectricChargeTest : StringSpec({
         checkAll(Arb.bigDecimal()) { magnitude ->
             magnitude.coulombs.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe ElectricCharge.SYMBOL
+                expression shouldBe Scalar(Metric.BASE, ElectricCharge.SYMBOL)
                 symbol shouldBe ElectricCharge.SYMBOL
             }
         }

--- a/lib/src/test/kotlin/org/kisu/units/derived/ElectricPotentialTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/derived/ElectricPotentialTest.kt
@@ -5,8 +5,10 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.checkAll
+import org.kisu.prefixes.Metric
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
+import org.kisu.units.Scalar
 import org.kisu.units.builders.volts
 
 class ElectricPotentialTest : StringSpec({
@@ -14,7 +16,7 @@ class ElectricPotentialTest : StringSpec({
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().volts.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe "${magnitude.builder().metric.symbol}${ElectricPotential.SYMBOL}"
+                expression shouldBe Scalar(magnitude.builder().metric, ElectricPotential.SYMBOL)
                 symbol shouldBe ElectricPotential.SYMBOL
             }
         }
@@ -24,7 +26,7 @@ class ElectricPotentialTest : StringSpec({
         checkAll(Arb.bigDecimal()) { magnitude ->
             magnitude.volts.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe ElectricPotential.SYMBOL
+                expression shouldBe Scalar(Metric.BASE, ElectricPotential.SYMBOL)
                 symbol shouldBe ElectricPotential.SYMBOL
             }
         }

--- a/lib/src/test/kotlin/org/kisu/units/derived/EnergyTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/derived/EnergyTest.kt
@@ -5,8 +5,10 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.checkAll
+import org.kisu.prefixes.Metric
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
+import org.kisu.units.Scalar
 import org.kisu.units.builders.joules
 
 class EnergyTest : StringSpec({
@@ -14,7 +16,7 @@ class EnergyTest : StringSpec({
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().joules.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe "${magnitude.builder().metric.symbol}${Energy.SYMBOL}"
+                expression shouldBe Scalar(magnitude.builder().metric, Energy.SYMBOL)
                 symbol shouldBe Energy.SYMBOL
             }
         }
@@ -24,7 +26,7 @@ class EnergyTest : StringSpec({
         checkAll(Arb.bigDecimal()) { magnitude ->
             magnitude.joules.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe Energy.SYMBOL
+                expression shouldBe Scalar(Metric.BASE, Energy.SYMBOL)
                 symbol shouldBe Energy.SYMBOL
             }
         }

--- a/lib/src/test/kotlin/org/kisu/units/derived/ForceTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/derived/ForceTest.kt
@@ -5,8 +5,10 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.checkAll
+import org.kisu.prefixes.Metric
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
+import org.kisu.units.Scalar
 import org.kisu.units.builders.newtons
 
 class ForceTest : StringSpec({
@@ -14,7 +16,7 @@ class ForceTest : StringSpec({
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().newtons.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe "${magnitude.builder().metric.symbol}${Force.SYMBOL}"
+                expression shouldBe Scalar(magnitude.builder().metric, Force.SYMBOL)
                 symbol shouldBe Force.SYMBOL
             }
         }
@@ -24,7 +26,7 @@ class ForceTest : StringSpec({
         checkAll(Arb.bigDecimal()) { magnitude ->
             magnitude.newtons.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe Force.SYMBOL
+                expression shouldBe Scalar(Metric.BASE, Force.SYMBOL)
                 symbol shouldBe Force.SYMBOL
             }
         }

--- a/lib/src/test/kotlin/org/kisu/units/derived/FrequencyTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/derived/FrequencyTest.kt
@@ -5,8 +5,10 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.checkAll
+import org.kisu.prefixes.Metric
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
+import org.kisu.units.Scalar
 import org.kisu.units.builders.hertz
 
 class FrequencyTest : StringSpec({
@@ -14,7 +16,7 @@ class FrequencyTest : StringSpec({
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().hertz.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe "${magnitude.builder().metric.symbol}${Frequency.SYMBOL}"
+                expression shouldBe Scalar(magnitude.builder().metric, Frequency.SYMBOL)
                 symbol shouldBe Frequency.SYMBOL
             }
         }
@@ -24,7 +26,7 @@ class FrequencyTest : StringSpec({
         checkAll(Arb.bigDecimal()) { magnitude ->
             magnitude.hertz.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe Frequency.SYMBOL
+                expression shouldBe Scalar(Metric.BASE, Frequency.SYMBOL)
                 symbol shouldBe Frequency.SYMBOL
             }
         }

--- a/lib/src/test/kotlin/org/kisu/units/derived/IlluminanceTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/derived/IlluminanceTest.kt
@@ -5,8 +5,10 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.checkAll
+import org.kisu.prefixes.Metric
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
+import org.kisu.units.Scalar
 import org.kisu.units.builders.lux
 
 class IlluminanceTest : StringSpec({
@@ -14,7 +16,7 @@ class IlluminanceTest : StringSpec({
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().lux.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe "${magnitude.builder().metric.symbol}${Illuminance.SYMBOL}"
+                expression shouldBe Scalar(magnitude.builder().metric, Illuminance.SYMBOL)
                 symbol shouldBe Illuminance.SYMBOL
             }
         }
@@ -24,7 +26,7 @@ class IlluminanceTest : StringSpec({
         checkAll(Arb.bigDecimal()) { magnitude ->
             magnitude.lux.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe Illuminance.SYMBOL
+                expression shouldBe Scalar(Metric.BASE, Illuminance.SYMBOL)
                 symbol shouldBe Illuminance.SYMBOL
             }
         }

--- a/lib/src/test/kotlin/org/kisu/units/derived/InductanceTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/derived/InductanceTest.kt
@@ -5,8 +5,10 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.checkAll
+import org.kisu.prefixes.Metric
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
+import org.kisu.units.Scalar
 import org.kisu.units.builders.henries
 
 class InductanceTest : StringSpec({
@@ -14,7 +16,7 @@ class InductanceTest : StringSpec({
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().henries.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe "${magnitude.builder().metric.symbol}${Inductance.SYMBOL}"
+                expression shouldBe Scalar(magnitude.builder().metric, Inductance.SYMBOL)
                 symbol shouldBe Inductance.SYMBOL
             }
         }
@@ -24,7 +26,7 @@ class InductanceTest : StringSpec({
         checkAll(Arb.bigDecimal()) { magnitude ->
             magnitude.henries.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe Inductance.SYMBOL
+                expression shouldBe Scalar(Metric.BASE, Inductance.SYMBOL)
                 symbol shouldBe Inductance.SYMBOL
             }
         }

--- a/lib/src/test/kotlin/org/kisu/units/derived/LuminousFluxTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/derived/LuminousFluxTest.kt
@@ -5,8 +5,10 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.checkAll
+import org.kisu.prefixes.Metric
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
+import org.kisu.units.Scalar
 import org.kisu.units.builders.lumens
 
 class LuminousFluxTest : StringSpec({
@@ -14,7 +16,7 @@ class LuminousFluxTest : StringSpec({
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().lumens.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe "${magnitude.builder().metric.symbol}${LuminousFlux.SYMBOL}"
+                expression shouldBe Scalar(magnitude.builder().metric, LuminousFlux.SYMBOL)
                 symbol shouldBe LuminousFlux.SYMBOL
             }
         }
@@ -24,7 +26,7 @@ class LuminousFluxTest : StringSpec({
         checkAll(Arb.bigDecimal()) { magnitude ->
             magnitude.lumens.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe LuminousFlux.SYMBOL
+                expression shouldBe Scalar(Metric.BASE, LuminousFlux.SYMBOL)
                 symbol shouldBe LuminousFlux.SYMBOL
             }
         }

--- a/lib/src/test/kotlin/org/kisu/units/derived/MagneticFluxDensityTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/derived/MagneticFluxDensityTest.kt
@@ -5,8 +5,10 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.checkAll
+import org.kisu.prefixes.Metric
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
+import org.kisu.units.Scalar
 import org.kisu.units.builders.teslas
 
 class MagneticFluxDensityTest : StringSpec({
@@ -14,7 +16,7 @@ class MagneticFluxDensityTest : StringSpec({
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().teslas.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe "${magnitude.builder().metric.symbol}${MagneticFluxDensity.SYMBOL}"
+                expression shouldBe Scalar(magnitude.builder().metric, MagneticFluxDensity.SYMBOL)
                 symbol shouldBe MagneticFluxDensity.SYMBOL
             }
         }
@@ -24,7 +26,7 @@ class MagneticFluxDensityTest : StringSpec({
         checkAll(Arb.bigDecimal()) { magnitude ->
             magnitude.teslas.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe MagneticFluxDensity.SYMBOL
+                expression shouldBe Scalar(Metric.BASE, MagneticFluxDensity.SYMBOL)
                 symbol shouldBe MagneticFluxDensity.SYMBOL
             }
         }

--- a/lib/src/test/kotlin/org/kisu/units/derived/MagneticFluxTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/derived/MagneticFluxTest.kt
@@ -5,8 +5,10 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.checkAll
+import org.kisu.prefixes.Metric
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
+import org.kisu.units.Scalar
 import org.kisu.units.builders.webers
 
 class MagneticFluxTest : StringSpec({
@@ -14,7 +16,7 @@ class MagneticFluxTest : StringSpec({
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().webers.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe "${magnitude.builder().metric.symbol}${MagneticFlux.SYMBOL}"
+                expression shouldBe Scalar(magnitude.builder().metric, MagneticFlux.SYMBOL)
                 symbol shouldBe MagneticFlux.SYMBOL
             }
         }
@@ -24,7 +26,7 @@ class MagneticFluxTest : StringSpec({
         checkAll(Arb.bigDecimal()) { magnitude ->
             magnitude.webers.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe MagneticFlux.SYMBOL
+                expression shouldBe Scalar(Metric.BASE, MagneticFlux.SYMBOL)
                 symbol shouldBe MagneticFlux.SYMBOL
             }
         }

--- a/lib/src/test/kotlin/org/kisu/units/derived/PlaneAngleTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/derived/PlaneAngleTest.kt
@@ -5,8 +5,10 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.checkAll
+import org.kisu.prefixes.Metric
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
+import org.kisu.units.Scalar
 import org.kisu.units.builders.radians
 
 class PlaneAngleTest : StringSpec({
@@ -15,7 +17,7 @@ class PlaneAngleTest : StringSpec({
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().radians.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe "${magnitude.builder().metric.symbol}${PlaneAngle.SYMBOL}"
+                expression shouldBe Scalar(magnitude.builder().metric, PlaneAngle.SYMBOL)
                 symbol shouldBe PlaneAngle.SYMBOL
             }
         }
@@ -25,7 +27,7 @@ class PlaneAngleTest : StringSpec({
         checkAll(Arb.bigDecimal()) { magnitude ->
             magnitude.radians.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe PlaneAngle.SYMBOL
+                expression shouldBe Scalar(Metric.BASE, PlaneAngle.SYMBOL)
                 symbol shouldBe PlaneAngle.SYMBOL
             }
         }

--- a/lib/src/test/kotlin/org/kisu/units/derived/PowerTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/derived/PowerTest.kt
@@ -5,8 +5,10 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.checkAll
+import org.kisu.prefixes.Metric
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
+import org.kisu.units.Scalar
 import org.kisu.units.builders.watts
 
 class PowerTest : StringSpec({
@@ -14,7 +16,7 @@ class PowerTest : StringSpec({
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().watts.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe "${magnitude.builder().metric.symbol}${Power.SYMBOL}"
+                expression shouldBe Scalar(magnitude.builder().metric, Power.SYMBOL)
                 symbol shouldBe Power.SYMBOL
             }
         }
@@ -24,7 +26,7 @@ class PowerTest : StringSpec({
         checkAll(Arb.bigDecimal()) { magnitude ->
             magnitude.watts.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe Power.SYMBOL
+                expression shouldBe Scalar(Metric.BASE, Power.SYMBOL)
                 symbol shouldBe Power.SYMBOL
             }
         }

--- a/lib/src/test/kotlin/org/kisu/units/derived/PressureTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/derived/PressureTest.kt
@@ -5,8 +5,10 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.checkAll
+import org.kisu.prefixes.Metric
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
+import org.kisu.units.Scalar
 import org.kisu.units.builders.pascals
 
 class PressureTest : StringSpec({
@@ -14,7 +16,7 @@ class PressureTest : StringSpec({
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().pascals.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe "${magnitude.builder().metric.symbol}${Pressure.SYMBOL}"
+                expression shouldBe Scalar(magnitude.builder().metric, Pressure.SYMBOL)
                 symbol shouldBe Pressure.SYMBOL
             }
         }
@@ -24,7 +26,7 @@ class PressureTest : StringSpec({
         checkAll(Arb.bigDecimal()) { magnitude ->
             magnitude.pascals.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe Pressure.SYMBOL
+                expression shouldBe Scalar(Metric.BASE, Pressure.SYMBOL)
                 symbol shouldBe Pressure.SYMBOL
             }
         }

--- a/lib/src/test/kotlin/org/kisu/units/derived/RadioactivityTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/derived/RadioactivityTest.kt
@@ -5,8 +5,10 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.checkAll
+import org.kisu.prefixes.Metric
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
+import org.kisu.units.Scalar
 import org.kisu.units.builders.becquerels
 
 class RadioactivityTest : StringSpec({
@@ -14,7 +16,7 @@ class RadioactivityTest : StringSpec({
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().becquerels.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe "${magnitude.builder().metric.symbol}${Radioactivity.SYMBOL}"
+                expression shouldBe Scalar(magnitude.builder().metric, Radioactivity.SYMBOL)
                 symbol shouldBe Radioactivity.SYMBOL
             }
         }
@@ -24,7 +26,7 @@ class RadioactivityTest : StringSpec({
         checkAll(Arb.bigDecimal()) { magnitude ->
             magnitude.becquerels.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe Radioactivity.SYMBOL
+                expression shouldBe Scalar(Metric.BASE, Radioactivity.SYMBOL)
                 symbol shouldBe Radioactivity.SYMBOL
             }
         }

--- a/lib/src/test/kotlin/org/kisu/units/derived/ResistanceTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/derived/ResistanceTest.kt
@@ -5,8 +5,10 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.checkAll
+import org.kisu.prefixes.Metric
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
+import org.kisu.units.Scalar
 import org.kisu.units.builders.ohms
 
 class ResistanceTest : StringSpec({
@@ -14,7 +16,7 @@ class ResistanceTest : StringSpec({
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().ohms.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe "${magnitude.builder().metric.symbol}${Resistance.SYMBOL}"
+                expression shouldBe Scalar(magnitude.builder().metric, Resistance.SYMBOL)
                 symbol shouldBe Resistance.SYMBOL
             }
         }
@@ -24,7 +26,7 @@ class ResistanceTest : StringSpec({
         checkAll(Arb.bigDecimal()) { magnitude ->
             magnitude.ohms.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe Resistance.SYMBOL
+                expression shouldBe Scalar(Metric.BASE, Resistance.SYMBOL)
                 symbol shouldBe Resistance.SYMBOL
             }
         }

--- a/lib/src/test/kotlin/org/kisu/units/derived/SolidAngleTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/derived/SolidAngleTest.kt
@@ -5,8 +5,10 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.checkAll
+import org.kisu.prefixes.Metric
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
+import org.kisu.units.Scalar
 import org.kisu.units.builders.steradians
 
 class SolidAngleTest : StringSpec({
@@ -14,7 +16,7 @@ class SolidAngleTest : StringSpec({
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().steradians.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe "${magnitude.builder().metric.symbol}${SolidAngle.SYMBOL}"
+                expression shouldBe Scalar(magnitude.builder().metric, SolidAngle.SYMBOL)
                 symbol shouldBe SolidAngle.SYMBOL
             }
         }
@@ -24,7 +26,7 @@ class SolidAngleTest : StringSpec({
         checkAll(Arb.bigDecimal()) { magnitude ->
             magnitude.steradians.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe SolidAngle.SYMBOL
+                expression shouldBe Scalar(Metric.BASE, SolidAngle.SYMBOL)
                 symbol shouldBe SolidAngle.SYMBOL
             }
         }

--- a/lib/src/test/kotlin/org/kisu/units/derived/VolumeTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/derived/VolumeTest.kt
@@ -5,8 +5,10 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.checkAll
+import org.kisu.prefixes.Metric
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
+import org.kisu.units.Scalar
 import org.kisu.units.builders.cubicMeters
 
 class VolumeTest : StringSpec({
@@ -14,7 +16,7 @@ class VolumeTest : StringSpec({
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().cubicMeters.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe "${magnitude.builder().metric.symbol}${Volume.SYMBOL}"
+                expression shouldBe Scalar(magnitude.builder().metric, Volume.SYMBOL)
                 symbol shouldBe Volume.SYMBOL
             }
         }
@@ -24,7 +26,7 @@ class VolumeTest : StringSpec({
         checkAll(Arb.bigDecimal()) { magnitude ->
             magnitude.cubicMeters.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe Volume.SYMBOL
+                expression shouldBe Scalar(Metric.BASE, Volume.SYMBOL)
                 symbol shouldBe Volume.SYMBOL
             }
         }


### PR DESCRIPTION
## 🐞 Problem to Solve

In order to support the construction of complex measures —such as products and quotients of multiple units—it’s necessary to work directly with the underlying `Expression<A>` that describes the unit's structure.

## 💡 Solution

Changed `operator fun component2(): A` to the `Measure` class.

---
  
  ✅ **Checklist**

- [X] The PR includes a clear and descriptive title
- [X] Related issue(s) are linked in the PR body
- [X] The solution is explained thoroughly
- [X] Tests or proofs are included

