### PR TITLE
[KISU-49] Add Expression algebra

### DIFF
--- a/lib/src/main/kotlin/org/kisu/units/Quotient.kt
+++ b/lib/src/main/kotlin/org/kisu/units/Quotient.kt
@@ -2,42 +2,162 @@ package org.kisu.units
 
 import org.kisu.KisuConfig
 import org.kisu.compositeRepresentation
+import org.kisu.prefixes.Prefix
 import org.kisu.prefixes.primitives.CompositeSystem
 import org.kisu.prefixes.primitives.System
 import java.math.BigDecimal
 
 /**
- * Represents a composite [Expression] formed by the quotient of two other expressions,
- * such as "m/s" (meter per second) or "J/(mol·K)" (joule per mole-kelvin).
+ * Represents the quotient of two unit expressions in the physical unit system.
  *
- * This class models divisive unit relationships, combining a numerator and a denominator,
- * and delegates [System] behavior to a [CompositeSystem] that understands both sides.
+ * This class is part of the expression system used to model complex **divisive physical units**,
+ * such as:
+ * - `m/s` (meter per second)
+ * - `J/(mol·K)` (joule per mole-kelvin)
+ * - `(kg·m)/(s²)` (newton)
  *
- * The resulting symbol is a slash-separated string of the numerator and denominator
- * composite representations. If either side is itself a composite (e.g., a [Product] or [Quotient]),
- * its representation is wrapped in parentheses to preserve grouping — e.g., "(kg·m)/(s²)".
+ * A [Quotient] is formed by dividing a [numerator] expression by a [denominator] expression,
+ * both of which are themselves required to be [Expression]s and [System]s.
  *
- * @param A the type of the numerator expression.
- * @param B the type of the denominator expression.
- * @property numerator the expression on the top of the quotient.
- * @property denominator the expression on the bottom of the quotient.
+ * It preserves mathematical and symbolic correctness by:
+ * - Delegating system behavior to a [CompositeSystem]
+ * - Automatically wrapping composite expressions in parentheses in the unit symbol
+ * - Computing the resulting factor as the division of numerator and denominator factors
+ *
+ * @param A the type of the numerator expression (e.g., `Joule`, `Meter`, or a [Product])
+ * @param B the type of the denominator expression (e.g., `Second`, `mol·K`, or another [Product])
+ * @property numerator the expression in the numerator of the quotient
+ * @property denominator the expression in the denominator of the quotient
  */
 class Quotient<A, B>(
     private val numerator: A,
     private val denominator: B
-) : Expression<Quotient<A, B>>(), System<Quotient<A, B>> by CompositeSystem(numerator, denominator, ::Quotient)
+) : Expression<Quotient<A, B>>(),
+    System<Quotient<A, B>> by CompositeSystem(numerator, denominator, ::Quotient)
     where A : Expression<A>, A : System<A>, B : Expression<B>, B : System<B> {
 
-    /** The combined factor of the quotient, equal to numerator divided by denominator. */
+    /**
+     * The numeric factor of the quotient, computed as numerator divided by denominator.
+     *
+     * This ensures accurate scaling for expressions involving prefixed units such as
+     * `kN/s`, `MJ/(mol·K)`, or `μA/mm²`.
+     */
     override val factor: BigDecimal by lazy {
         numerator.factor.divide(denominator.factor, KisuConfig.precision)
     }
 
     /**
-     * The combined symbol, rendered as "numerator/denominator". If either operand is a composite expression,
-     * its representation will be wrapped in parentheses — e.g., "W/(m·K)".
+     * The symbol for this quotient expression, rendered as `"numerator/denominator"`.
+     *
+     * If the denominator is a composite expression (e.g., a [Product] or nested [Quotient]),
+     * it is wrapped in parentheses to preserve grouping — for example:
+     * - `"J/mol·K"` → `J/(mol·K)`
+     * - `"kg·m/s²"` → `(kg·m)/(s²)`
      */
     override val symbol: String by lazy {
-        "${numerator.compositeRepresentation}/${denominator.compositeRepresentation}"
+        "$numerator/${denominator.compositeRepresentation}"
     }
+
+    /**
+     * Returns the numerator component of the quotient.
+     */
+    operator fun component1() = numerator
+
+    /**
+     * Returns the denominator component of the quotient.
+     */
+    operator fun component2() = denominator
+
+    /**
+     * Multiplies this quotient by a scalar unit expression.
+     *
+     * This multiplies the numerator by the scalar, leaving the denominator unchanged.
+     *
+     * Algebra: (*A* / *B*) · *C* = (*A* · *C*) / *B*
+     *
+     * Example:
+     * `(J / mol·K) * μ = (J·μ) / (mol·K)`
+     * Represents joule times micro in numerator per mole kelvin in denominator.
+     */
+    operator fun <C> times(other: Scalar<C>): Quotient<Product<A, Scalar<C>>, B>
+        where C : Prefix<C>, C : System<C> =
+        Quotient(Product(numerator, other), denominator)
+
+    /**
+     * Multiplies this quotient by a product of two unit expressions.
+     *
+     * This multiplies the numerator by the entire product expression.
+     *
+     * Algebra: (*A* / *B*) · (*C* · *D*) = (*A* · *C* · *D*) / *B*
+     *
+     * Example:
+     * `(m / s) * (kg · s) = (m · kg · s) / s`
+     * Represents meter times kilogram times second, divided by second.
+     */
+    operator fun <C, D> times(other: Product<C, D>): Quotient<Product<A, Product<C, D>>, B>
+        where C : Expression<C>, C : System<C>, D : Expression<D>, D : System<D> =
+        Quotient(Product(numerator, other), denominator)
+
+    /**
+     * Multiplies this quotient by another quotient.
+     *
+     * Both numerators multiply and both denominators multiply.
+     *
+     * Algebra: (*A* / *B*) · (*C* / *D*) = (*A* · *C*) / (*B* · *D*)
+     *
+     * Example:
+     * `(J / mol·K) * (V / A) = (J · V) / (mol · K · A)`
+     * Represents joule volt per mole kelvin ampere.
+     */
+    operator fun <C, D> times(other: Quotient<C, D>): Quotient<Product<A, C>, Product<B, D>>
+        where C : Expression<C>, C : System<C>, D : Expression<D>, D : System<D> =
+        Quotient(
+            Product(numerator, other.numerator),
+            Product(denominator, other.denominator)
+        )
+
+    /**
+     * Divides this quotient by a scalar unit expression.
+     *
+     * This multiplies the denominator by the scalar.
+     *
+     * Algebra: (*A* / *B*) / *C* = *A* / (*B* · *C*)
+     *
+     * Example:
+     * `(J / mol·K) / μ = J / (mol · K · μ)`
+     * Represents joule per mole kelvin micro.
+     */
+    operator fun <C> div(other: Scalar<C>): Quotient<A, Product<B, Scalar<C>>>
+        where C : Prefix<C>, C : System<C> =
+        Quotient(numerator, Product(denominator, other))
+
+    /**
+     * Divides this quotient by a product of two unit expressions.
+     *
+     * The denominator is extended by the product.
+     *
+     * Algebra: (*A* / *B*) / (*C* · *D*) = *A* / (*B* · *C* · *D*)
+     *
+     * Example:
+     * `(kg · m / s²) / (mol · K) = (kg · m) / (s² · mol · K)`
+     * Represents kilogram meter over second squared mole kelvin.
+     */
+    operator fun <C, D> div(other: Product<C, D>): Quotient<A, Product<B, Product<C, D>>>
+        where C : Expression<C>, C : System<C>, D : Expression<D>, D : System<D> =
+        Quotient(numerator, Product(denominator, other))
+
+    /**
+     * Divides this quotient by another quotient.
+     *
+     * Inverts the divisor and multiplies numerator and denominator accordingly.
+     *
+     * Algebra: (*A* / *B*) / (*C* / *D*) = (*A* · *D*) / (*B* · *C*)
+     *
+     * Example:
+     * `(a / b) / (c / d) = (a · d) / (b · c)`
+     * For example, `(J / mol·K) / (V / A) = (J · A) / (mol · K · V)`
+     */
+    operator fun <C, D> div(other: Quotient<C, D>)
+    where C : Expression<C>, C : System<C>, D : Expression<D>, D : System<D> =
+        Quotient(Product(numerator, other.denominator), Product(denominator, other.numerator))
 }

--- a/lib/src/main/kotlin/org/kisu/units/Scalar.kt
+++ b/lib/src/main/kotlin/org/kisu/units/Scalar.kt
@@ -6,17 +6,20 @@ import org.kisu.prefixes.primitives.System
 import java.math.BigDecimal
 
 /**
- * Represents a scalar unit composed of a [Prefix] and a unit symbol, such as "km" (kilo + meter)
- * or "μs" (micro + second).
+ * Represents a scalar unit, composed of a [Prefix] and a unit symbol (e.g., "km" for kilo + meter, "μs" for micro +
+ * second).
  *
- * This is the base case of an [Expression], used to join together a prefix and a raw unit string,
- * producing a complete symbol representation (e.g., "k" + "m" → "km").
+ * This is the atomic element of the [Expression] system, which models complex unit compositions such as "N⋅m" or
+ * "mol⋅K".
  *
- * It delegates [System] behavior to a [ScalarSystem] composed of the same prefix and unit.
+ * A [Scalar] combines a prefix and a base unit into a single symbolic component, and can be composed with other
+ * expressions through multiplication and division to form [Product] and [Quotient] types.
+ *
+ * It delegates [System] behavior to a [ScalarSystem] built from the same prefix and unit.
  *
  * @param A the type of prefix used in this scalar unit.
- * @property prefix the prefix applied to the unit (e.g., kilo, milli).
- * @property unit the symbol of the unit itself (e.g., "m" for meter).
+ * @property prefix the prefix applied to the unit (e.g., kilo, micro).
+ * @property unit the base unit symbol (e.g., "m" for meter, "s" for second).
  */
 class Scalar<A>(
     private val prefix: A,
@@ -29,4 +32,69 @@ class Scalar<A>(
 
     /** The combined symbol of the prefix and unit (e.g., "km", "μs"). */
     override val symbol: String by lazy { prefix.symbol + unit }
+
+    /**
+     * Multiplies this scalar unit with another scalar unit, returning a [Product] expression.
+     *
+     * Algebra: *A* · *B*
+     *
+     * Example: `km · ms` → a scalar product representing kilometre·millisecond.
+     */
+    operator fun <B> times(other: Scalar<B>): Product<Scalar<A>, Scalar<B>> where B : Prefix<B>, B : System<B> =
+        Product(this, other)
+
+    /**
+     * Multiplies this scalar unit with an existing [Product], producing a nested [Product] expression.
+     *
+     * Algebra: *A* · (*B* · *C*)
+     *
+     * Example: `km · (ms · Mg)` → kilometre·millisecond·megagram (nested structure preserved).
+     */
+    operator fun <B, C> times(other: Product<B, C>): Product<Scalar<A>, Product<B, C>>
+        where B : Expression<B>, B : System<B>, C : Expression<C>, C : System<C> =
+        Product(this, other)
+
+    /**
+     * Multiplies this scalar unit with a [Quotient], producing a [Quotient] where the numerator is a [Product].
+     *
+     * Algebra: *A* · (*B* / *C*) = (*A* · *B*) / *C*
+     *
+     * Example: `km · (ms / ng)` → (kilometre·millisecond) / nanogram
+     */
+    operator fun <B, C> times(other: Quotient<B, C>): Quotient<Product<Scalar<A>, B>, C>
+        where B : Expression<B>, B : System<B>, C : Expression<C>, C : System<C> =
+        Quotient(Product(this, other.component1()), other.component2())
+
+    /**
+     * Divides this scalar unit by another scalar unit, producing a [Quotient] expression.
+     *
+     * Algebra: *A* / *B*
+     *
+     * Example: `km / ms` → kilometre / millisecond
+     */
+    operator fun <B> div(other: Scalar<B>): Quotient<Scalar<A>, Scalar<B>> where B : Prefix<B>, B : System<B> =
+        Quotient(this, other)
+
+    /**
+     * Divides this scalar unit by a [Product], producing a [Quotient] with a product in the denominator.
+     *
+     * Algebra: *A* / (*B* · *C*)
+     *
+     * Example: `km / (ms · Mg)` → kilometre / (millisecond·megagram)
+     */
+    operator fun <B, C> div(other: Product<B, C>): Quotient<Scalar<A>, Product<B, C>>
+        where B : Expression<B>, B : System<B>, C : Expression<C>, C : System<C> =
+        Quotient(this, other)
+
+    /**
+     * Divides this scalar unit by a [Quotient], producing a [Quotient] where the original denominator becomes the
+     * numerator.
+     *
+     * Algebra: *A* / (*B* / *C*) = (*A* · *C*) / *B*
+     *
+     * Example: `km / (ms / ng)` → (kilometre·nanogram) / millisecond
+     */
+    operator fun <B, C> div(other: Quotient<B, C>): Quotient<Product<Scalar<A>, C>, B>
+        where B : Expression<B>, B : System<B>, C : Expression<C>, C : System<C> =
+        Quotient(Product(this, other.component2()), other.component1())
 }

--- a/lib/src/test/kotlin/org/kisu/test/generators/Scalars.kt
+++ b/lib/src/test/kotlin/org/kisu/test/generators/Scalars.kt
@@ -1,0 +1,11 @@
+package org.kisu.test.generators
+
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.bind
+import org.kisu.prefixes.Metric
+import org.kisu.units.Scalar
+
+object Scalars : Generator<Scalar<Metric>> {
+    override val generator: Arb<Scalar<Metric>> =
+        Arb.bind(Metrics.generator, Units.generator) { prefix, unit -> Scalar(prefix, unit) }
+}

--- a/lib/src/test/kotlin/org/kisu/test/generators/Units.kt
+++ b/lib/src/test/kotlin/org/kisu/test/generators/Units.kt
@@ -1,0 +1,9 @@
+package org.kisu.test.generators
+
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.char
+import io.kotest.property.arbitrary.map
+
+object Units : Generator<String> {
+    override val generator: Arb<String> = Arb.char('a'..'z').map { it.toString() }
+}

--- a/lib/src/test/kotlin/org/kisu/units/ProductTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/ProductTest.kt
@@ -6,6 +6,7 @@ import io.kotest.property.checkAll
 import org.kisu.test.fakes.TestUnit
 import org.kisu.test.generators.Binaries
 import org.kisu.test.generators.Metrics
+import org.kisu.test.generators.Scalars
 
 class ProductTest : StringSpec({
     "factor is the product of both prefixes" {
@@ -36,5 +37,61 @@ class ProductTest : StringSpec({
             )
             expression.symbol shouldBe expression.toString()
         }
+    }
+
+    "multiplying a Product and a Scalar makes a Product" {
+        checkAll(
+            Scalars.generator,
+            Scalars.generator,
+            Scalars.generator
+        ) { a, b, c -> ((a * b) * c).symbol shouldBe "$a·$b·$c" }
+    }
+
+    "multiplying two Products makes a nested Product" {
+        checkAll(
+            Scalars.generator,
+            Scalars.generator,
+            Scalars.generator,
+            Scalars.generator
+        ) { a, b, c, d -> ((a * b) * (c * d)).symbol shouldBe "$a·$b·$c·$d" }
+    }
+
+    "multiplying a Product and a Quotient makes a Quotient with a Product numerator" {
+        checkAll(
+            Scalars.generator,
+            Scalars.generator,
+            Scalars.generator,
+            Scalars.generator
+        ) { a, b, c, d ->
+            ((a * b) * (c / d)).symbol shouldBe "$a·$b·$c/$d"
+        }
+    }
+
+    "dividing a Product by a Scalar makes a Quotient" {
+        checkAll(
+            Scalars.generator,
+            Scalars.generator,
+            Scalars.generator
+        ) { a, b, c ->
+            ((a * b) / c).symbol shouldBe "$a·$b/$c"
+        }
+    }
+
+    "dividing a Product by a Product makes a Quotient" {
+        checkAll(
+            Scalars.generator,
+            Scalars.generator,
+            Scalars.generator,
+            Scalars.generator
+        ) { a, b, c, d -> ((a * b) / (c * d)).symbol shouldBe "$a·$b/($c·$d)" }
+    }
+
+    "dividing a Product by a Quotient makes a nested Quotient" {
+        checkAll(
+            Scalars.generator,
+            Scalars.generator,
+            Scalars.generator,
+            Scalars.generator
+        ) { a, b, c, d -> ((a * b) / (c / d)).symbol shouldBe "$a·$b·$d/$c" }
     }
 })

--- a/lib/src/test/kotlin/org/kisu/units/QuotientTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/QuotientTest.kt
@@ -7,6 +7,7 @@ import org.kisu.KisuConfig
 import org.kisu.test.fakes.TestUnit
 import org.kisu.test.generators.Binaries
 import org.kisu.test.generators.Metrics
+import org.kisu.test.generators.Scalars
 
 class QuotientTest : StringSpec({
     "factor is the quotient of both prefixes" {
@@ -37,5 +38,59 @@ class QuotientTest : StringSpec({
             )
             expression.symbol shouldBe expression.toString()
         }
+    }
+
+    "multiplying a Quotient and a Scalar makes a Quotient with Product numerator" {
+        checkAll(
+            Scalars.generator,
+            Scalars.generator,
+            Scalars.generator
+        ) { a, b, c -> ((a / b) * c).symbol shouldBe "$a·$c/$b" }
+    }
+
+    "multiplying a Quotient and a Product makes a Quotient with Product numerator" {
+        checkAll(
+            Scalars.generator,
+            Scalars.generator,
+            Scalars.generator,
+            Scalars.generator
+        ) { a, b, c, d -> ((a / b) * (c * d)).symbol shouldBe "$a·$c·$d/$b" }
+    }
+
+    "multiplying two Quotients makes a Quotient with Product numerator and denominator" {
+        checkAll(
+            Scalars.generator,
+            Scalars.generator,
+            Scalars.generator,
+            Scalars.generator
+        ) { a, b, c, d -> ((a / b) * (c / d)).symbol shouldBe "$a·$c/($b·$d)" }
+    }
+
+    "dividing a Quotient by a Scalar makes a Quotient with Product denominator" {
+        checkAll(
+            Scalars.generator,
+            Scalars.generator,
+            Scalars.generator
+        ) { a, b, c -> ((a / b) / c).symbol shouldBe "$a/($b·$c)" }
+    }
+
+    "dividing a Quotient by a Product makes a Quotient with Product denominator" {
+        checkAll(
+            Scalars.generator,
+            Scalars.generator,
+            Scalars.generator,
+            Scalars.generator
+        ) { a, b, c, d ->
+            ((a / b) / (c * d)).symbol shouldBe "$a/($b·$c·$d)"
+        }
+    }
+
+    "dividing a Quotient by a Quotient flips and multiplies the inner Quotient" {
+        checkAll(
+            Scalars.generator,
+            Scalars.generator,
+            Scalars.generator,
+            Scalars.generator
+        ) { a, b, c, d -> ((a / b) / (c / d)).symbol shouldBe "$a·$d/($b·$c)" }
     }
 })

--- a/lib/src/test/kotlin/org/kisu/units/ScalarTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/ScalarTest.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.property.checkAll
 import org.kisu.test.fakes.TestUnit
 import org.kisu.test.generators.Metrics
+import org.kisu.test.generators.Scalars
 
 class ScalarTest : StringSpec({
     "delegates factor to the prefix" {
@@ -24,5 +25,51 @@ class ScalarTest : StringSpec({
             val expression = Scalar(metric, TestUnit.SYMBOL)
             expression.symbol shouldBe expression.toString()
         }
+    }
+
+    "multiplying two scalars make a Product" {
+        checkAll(
+            Scalars.generator,
+            Scalars.generator
+        ) { a, b -> (a * b).symbol shouldBe "$a·$b" }
+    }
+
+    "multiplying a scalar and a Product make a Product" {
+        checkAll(
+            Scalars.generator,
+            Scalars.generator,
+            Scalars.generator
+        ) { a, b, c -> (a * (b * c)).symbol shouldBe "$a·$b·$c" }
+    }
+
+    "multiplying a scalar and a Quotient make a Quotient" {
+        checkAll(
+            Scalars.generator,
+            Scalars.generator,
+            Scalars.generator
+        ) { a, b, c -> (a * (b / c)).symbol shouldBe "$a·$b/$c" }
+    }
+
+    "dividing two scalars make a Quotient" {
+        checkAll(
+            Scalars.generator,
+            Scalars.generator
+        ) { a, b -> (a / b).symbol shouldBe "$a/$b" }
+    }
+
+    "dividing a scalar and a Product make a Quotient" {
+        checkAll(
+            Scalars.generator,
+            Scalars.generator,
+            Scalars.generator
+        ) { a, b, c -> (a / (b * c)).symbol shouldBe "$a/($b·$c)" }
+    }
+
+    "dividing a scalar and a Quotient make a Quotient" {
+        checkAll(
+            Scalars.generator,
+            Scalars.generator,
+            Scalars.generator
+        ) { a, b, c -> (a / (b / c)).symbol shouldBe "$a·$c/$b" }
     }
 })


### PR DESCRIPTION
 
## 🐞 Problem to Solve

This PR introduces a structured algebra for unit expressions, enabling precise manipulation and combination of units via type-safe classes.

## 💡 Solution

- **Scalar**: Represents a base unit with an optional prefix (e.g., km, μs).
- **Product**: Represents multiplication of two expressions (e.g., m·s).
- **Quotient**: Represents division between two expressions (e.g., m/s).
- Operator overloading for * and / to compose expressions naturally.
- Equality, hashing, and simplification logic for consistent expression comparison.
- Basic formatting and string representation.

Unit tests covering scalar, product, and quotient behavio


---
  
  ✅ **Checklist**

- [X] The PR includes a clear and descriptive title
- [X] Related issue(s) are linked in the PR body
- [X] The solution is explained thoroughly
- [X] Tests or proofs are included

