### PR TITLE
[KISU-61] Fixes Quotient exponent bug

### DIFF
--- a/lib/src/main/kotlin/org/kisu/units/representation/Quotient.kt
+++ b/lib/src/main/kotlin/org/kisu/units/representation/Quotient.kt
@@ -69,7 +69,8 @@ class Quotient<A, B>(
     override val symbol: String by lazy {
         val (numerators, denominators) = factors.partition { it.positive }
         val numerator = numerators.productSymbol
-        val denominator = denominators.productSymbol.let { if (denominators.size > 1) "($it)" else it }
+        val denominator = denominators.map { it.inverted }.productSymbol
+            .let { if (denominators.size > 1) "($it)" else it }
 
         when {
             numerators.isEmpty() && denominators.isEmpty() -> ""

--- a/lib/src/test/kotlin/org/kisu/units/representation/QuotientTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/representation/QuotientTest.kt
@@ -37,6 +37,17 @@ class QuotientTest : StringSpec({
         }
     }
 
+    "factors should merge equal units" {
+        checkAll(Scalars.distinct(2)) { (a, b) ->
+            val numerator = a * a
+            val denominator = b * b
+
+            val quotient = numerator / denominator
+
+            quotient.symbol shouldBe "${numerator.symbol}/${denominator.symbol}"
+        }
+    }
+
     "represents its symbol" {
         checkAll(
             Metrics.generator,


### PR DESCRIPTION
Closes #61 
  
## 🐞 Problem to Solve

The quotients in the denominator were not showing properly.

## 💡 Solution

Re-invert the denominator ones so they show appropiately.

---
  
  ✅ **Checklist**

- [X] The PR includes a clear and descriptive title
- [X] Related issue(s) are linked in the PR body
- [X] The solution is explained thoroughly
- [X] Tests or proofs are included

