### PR TITLE
[KISU-65] Change Unit contract to consider both exponent and symbol

### DIFF
--- a/lib/src/main/kotlin/org/kisu/units/representation/Unit.kt
+++ b/lib/src/main/kotlin/org/kisu/units/representation/Unit.kt
@@ -129,21 +129,6 @@ class Unit(
     }
 
     /**
-     * Checks equality based **only** on the [symbol] name, ignoring the exponent.
-     *
-     * This is intentional so units like "m²" and "m³" can be grouped or compared
-     * as the same base unit symbol.
-     */
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as Unit
-
-        return symbol == other.symbol
-    }
-
-    /**
      * Compares this [Unit] with another [Unit] for ordering.
      *
      * The comparison is based on the canonical order of unit symbols defined
@@ -163,15 +148,46 @@ class Unit(
         CANONICAL_ORDER.indexOf(this).compareTo(CANONICAL_ORDER.indexOf(other))
 
     /**
-     * Computes hash code based on the [symbol] only, ignoring the exponent.
-     */
-    override fun hashCode(): Int = symbol.hashCode()
-
-    /**
      * Returns the string representation of the unit, including superscript exponent
      * if applicable (e.g., `"m²"`).
      */
     override fun toString(): String = representation
+
+    /**
+     * Compares this [Unit] to another object for structural equality.
+     *
+     * Two [Unit] instances are considered equal if and only if:
+     * - They are of the same runtime type, and
+     * - Their [symbol] and [exponent] properties are equal.
+     *
+     * @param other the object to compare with.
+     * @return `true` if [other] is a [Unit] with the same [symbol] and [exponent], `false` otherwise.
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Unit
+
+        if (symbol != other.symbol) return false
+        if (exponent != other.exponent) return false
+
+        return true
+    }
+
+    /**
+     * Returns a hash code value for this [Unit].
+     *
+     * The hash code is computed from the [symbol] and [exponent] properties,
+     * ensuring consistency with [equals].
+     *
+     * @return an integer hash code for this [Unit].
+     */
+    override fun hashCode(): Int {
+        var result = symbol.hashCode()
+        result = 31 * result + exponent.hashCode()
+        return result
+    }
 }
 
 /**

--- a/lib/src/test/kotlin/org/kisu/units/representation/UnitTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/representation/UnitTest.kt
@@ -1,6 +1,7 @@
 package org.kisu.units.representation
 
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.common.DelicateKotest
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
@@ -9,12 +10,14 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.arbitrary
+import io.kotest.property.arbitrary.bind
 import io.kotest.property.arbitrary.filter
 import io.kotest.property.arbitrary.int
 import io.kotest.property.checkAll
 import org.kisu.test.generators.Exponents
 import org.kisu.test.generators.Units
 
+@OptIn(DelicateKotest::class)
 class UnitTest : StringSpec({
     "unit is recognized as positive" {
         checkAll(Units.symbols, Exponents.range(1, Int.MAX_VALUE)) { symbol, exponent ->
@@ -82,20 +85,22 @@ class UnitTest : StringSpec({
         }
     }
 
-    "equality only depends on unit name, not exponent" {
-        checkAll(Units.symbols, Arb.int(), Arb.int()) { unit, a, b ->
-            val u1 = Unit(unit, a)
-            val u2 = Unit(unit, b)
-
-            u1 shouldBe u2
-            u1.hashCode() shouldBe u2.hashCode()
-        }
-    }
-
-    "inequality when units differ" {
+    "is unequal when units differ" {
         checkAll(Arb.int()) { exponent ->
             val u1 = Unit("kg", exponent)
             val u2 = Unit("g", exponent)
+
+            u1 shouldNotBe u2
+        }
+    }
+
+    "is unequal when exponents differ" {
+        checkAll(
+            Arb.bind(Arb.int(), Arb.int()) { a, b -> a to b }
+                .filter { (a, b) -> a != b }
+        ) { (a, b) ->
+            val u1 = Unit("g", a)
+            val u2 = Unit("g", b)
 
             u1 shouldNotBe u2
         }


### PR DESCRIPTION
Closes #65 
  
## 🐞 Problem to Solve

This PR updates the `Unit` class to refine its equality and hash code contract.  

Both `symbol` and `exponent` are now considered when comparing two units or computing their hash codes.

## 💡 Solution

- **`equals`**:
  - Updated to return `true` only if both `symbol` and `exponent` match.
  - Prevents cases where units with the same symbol but different exponents (e.g. `m` vs. `m²`) were incorrectly treated as equal.
  
- **`hashCode`**:
  - Updated to compute its value from both `symbol` and `exponent`.
  - Ensures consistency with the new equality definition.

---
  
  ✅ **Checklist**

- [X] The PR includes a clear and descriptive title
- [X] Related issue(s) are linked in the PR body
- [X] The solution is explained thoroughly
- [X] Tests or proofs are included

