### PR TITLE
[KISU-69] Creates Photometry Units

### DIFF
--- a/lib/src/main/kotlin/org/kisu/units/photometric/Efficacy.kt
+++ b/lib/src/main/kotlin/org/kisu/units/photometric/Efficacy.kt
@@ -1,0 +1,28 @@
+package org.kisu.units.photometric
+
+import org.kisu.units.Measure
+import org.kisu.units.representation.Quotient
+import org.kisu.units.special.Lumen
+import org.kisu.units.special.Watt
+import java.math.BigDecimal
+
+typealias LumenPerWatt = Quotient<Lumen, Watt>
+
+/**
+ * Represents the **luminous efficacy** of a light source.
+ *
+ * Luminous efficacy is the ratio between the luminous flux (in lumens)
+ * and the power consumed (in watts). It indicates how efficiently a
+ * light source produces visible light.
+ *
+ * Expressed in **lumens per watt (lm/W)**.
+ *
+ * @constructor Creates a luminous efficacy measure with the given [magnitude]
+ * and [expression].
+ * @param magnitude The numeric value of the measure.
+ * @param expression The unit expression in lumens per watt.
+ */
+class Efficacy(
+    magnitude: BigDecimal,
+    expression: LumenPerWatt
+) : Measure<LumenPerWatt, Efficacy>(magnitude, expression, ::Efficacy)

--- a/lib/src/main/kotlin/org/kisu/units/photometric/Exposure.kt
+++ b/lib/src/main/kotlin/org/kisu/units/photometric/Exposure.kt
@@ -1,0 +1,31 @@
+package org.kisu.units.photometric
+
+import org.kisu.units.Measure
+import org.kisu.units.base.Second
+import org.kisu.units.representation.Product
+import org.kisu.units.special.Lux
+import java.math.BigDecimal
+
+typealias LuxSecond = Product<Lux, Second>
+
+/**
+ * Represents **luminous exposure**.
+ *
+ * Luminous exposure is the measure of the total luminous energy
+ * received per unit area, calculated as the product of illuminance
+ * (in lux) and time (in seconds).
+ *
+ * Expressed in **lux-seconds (lx·s)**.
+ *
+ * Commonly used in **photography** and **radiometry** to quantify the
+ * total light incident on a surface during an exposure.
+ *
+ * @constructor Creates a luminous exposure measure with the given [magnitude]
+ * and [expression].
+ * @param magnitude The numeric value of the measure.
+ * @param expression The unit expression in lux-seconds.
+ */
+class Exposure(
+    magnitude: BigDecimal,
+    expression: LuxSecond
+) : Measure<LuxSecond, Exposure>(magnitude, expression, ::Exposure)

--- a/lib/src/main/kotlin/org/kisu/units/photometric/Luminance.kt
+++ b/lib/src/main/kotlin/org/kisu/units/photometric/Luminance.kt
@@ -1,0 +1,33 @@
+package org.kisu.units.photometric
+
+import org.kisu.units.Measure
+import org.kisu.units.base.Candela
+import org.kisu.units.representation.Quotient
+import org.kisu.units.special.SquareMetre
+import java.math.BigDecimal
+
+typealias CandelaPerSquareMetre = Quotient<Candela, SquareMetre>
+
+/**
+ * Represents **luminance**.
+ *
+ * Luminance is the measure of the luminous intensity emitted,
+ * transmitted, or reflected from a surface in a given direction
+ * per unit area.
+ *
+ * Expressed in **candelas per square metre (cd/m²)**, also known as
+ * **nits** in display technology.
+ *
+ * It quantifies how bright a surface will appear to the human eye,
+ * making it a central concept in **optics, lighting engineering, and
+ * display calibration**.
+ *
+ * @constructor Creates a luminance measure with the given [magnitude]
+ * and [expression].
+ * @param magnitude The numeric value of the measure.
+ * @param expression The unit expression in candelas per square metre.
+ */
+class Luminance(
+    magnitude: BigDecimal,
+    expression: CandelaPerSquareMetre
+) : Measure<CandelaPerSquareMetre, Luminance>(magnitude, expression, ::Luminance)

--- a/lib/src/main/kotlin/org/kisu/units/photometric/LuminousEnergy.kt
+++ b/lib/src/main/kotlin/org/kisu/units/photometric/LuminousEnergy.kt
@@ -1,0 +1,31 @@
+package org.kisu.units.photometric
+
+import org.kisu.units.Measure
+import org.kisu.units.base.Second
+import org.kisu.units.representation.Product
+import org.kisu.units.special.Lumen
+import java.math.BigDecimal
+
+typealias LumenSecond = Product<Lumen, Second>
+
+/**
+ * Represents **luminous energy**.
+ *
+ * Luminous energy (also known as *quantity of light*) is the measure of the
+ * perceived amount of light emitted over a period of time.
+ *
+ * It is defined as the time integral of luminous flux and is expressed in
+ * **lumen-seconds (lm·s)**.
+ *
+ * This quantity is important in photometry when evaluating the total amount
+ * of light delivered by a source during a given interval.
+ *
+ * @constructor Creates a luminous energy measure with the given [magnitude]
+ * and [expression].
+ * @param magnitude The numeric value of the measure.
+ * @param expression The unit expression in lumen-seconds.
+ */
+class LuminousEnergy(
+    magnitude: BigDecimal,
+    expression: LumenSecond
+) : Measure<LumenSecond, LuminousEnergy>(magnitude, expression, ::LuminousEnergy)


### PR DESCRIPTION
Closes #69
  
## 🐞 Problem to Solve

This PR introduces **photometry-related SI derived units** into the measurement system.  
These additions expand support for representing light-related physical quantities in a consistent and type-safe way.

## 💡 Solution

## Added Units

- **Efficacy**: (lm·s)  
- **Exposure**: (lx·s)  
- **Luminance**: candela per square metre (cd/m²)  
- **Luminous energy**: (lm/W)  

---
  
  ✅ **Checklist**

- [X] The PR includes a clear and descriptive title
- [X] Related issue(s) are linked in the PR body
- [X] The solution is explained thoroughly
- [X] Tests or proofs are included

