### PR TITLE
[KISU-73] Creates Chemistry units

### DIFF
--- a/lib/src/main/kotlin/org/kisu/units/chemistry/CatalyticEfficiency.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/CatalyticEfficiency.kt
@@ -1,0 +1,54 @@
+package org.kisu.units.chemistry
+
+import org.kisu.units.Measure
+import org.kisu.units.base.Mol
+import org.kisu.units.base.Second
+import org.kisu.units.representation.Product
+import org.kisu.units.representation.Quotient
+import org.kisu.units.special.SquareMetre
+import java.math.BigDecimal
+
+/**
+ * Represents the SI unit **cubic metre per mole second (m³/(mol·s))**.
+ *
+ * This unit is used to measure **catalytic efficiency**, i.e., the volume of
+ * substrate converted per mole of catalyst per second.
+ * It is defined as the [Quotient] of [SquareMetre] (area) divided by the [Product]
+ * of [Mol] (amount of substance) and [Second] (time).
+ *
+ * Example usages include:
+ * - Characterising enzyme or catalyst performance in chemical reactions
+ * - Determining turnover rates in biochemistry and industrial catalysis
+ *
+ * @see CatalyticEfficiency for the physical quantity represented by this unit.
+ */
+typealias CubicMetrePerMoleSecond = Quotient<SquareMetre, Product<Mol, Second>>
+
+/**
+ * Represents the physical quantity of **catalytic efficiency**.
+ *
+ * Catalytic efficiency quantifies the **efficiency of an enzyme or catalyst
+ * in converting substrate molecules into product**.
+ * It is often expressed as the ratio *kcat/Km* in enzyme kinetics, where:
+ * - *kcat* is the catalytic turnover number
+ * - *Km* is the Michaelis–Menten constant
+ *
+ * Its SI unit is the **cubic metre per mole second (m³/(mol·s))**, represented here
+ * by [CubicMetrePerMoleSecond].
+ *
+ * Example usages include:
+ * - Characterising enzyme kinetics in biochemistry
+ * - Comparing catalytic effectiveness between different enzymes
+ * - Biotechnological and pharmaceutical applications
+ *
+ * The magnitude is stored as a [BigDecimal] to ensure high precision.
+ * Instances of [CatalyticEfficiency] are immutable, and the [expression] parameter ties
+ * the measurement to its unit representation ([CubicMetrePerMoleSecond]).
+ *
+ * @property magnitude The numeric value of the catalytic efficiency.
+ * @property expression The unit expression of the catalytic efficiency, always [CubicMetrePerMoleSecond].
+ */
+class CatalyticEfficiency(
+    magnitude: BigDecimal,
+    expression: CubicMetrePerMoleSecond
+) : Measure<CubicMetrePerMoleSecond, CatalyticEfficiency>(magnitude, expression, ::CatalyticEfficiency)

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/Molality.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/Molality.kt
@@ -1,0 +1,47 @@
+package org.kisu.units.chemistry
+
+import org.kisu.units.Measure
+import org.kisu.units.base.Kilogram
+import org.kisu.units.base.Mol
+import org.kisu.units.representation.Quotient
+import java.math.BigDecimal
+
+/**
+ * Represents the SI unit **mole per kilogram (mol/kg)**.
+ *
+ * This unit measures **molality**, i.e., the amount of substance per unit mass
+ * of solvent.
+ * It is defined as the [Quotient] of [Mol] (amount of substance) divided by [Kilogram] (mass).
+ *
+ * Example usages include:
+ * - Expressing solute concentration in chemistry and chemical engineering
+ * - Thermodynamic calculations involving colligative properties
+ *
+ * @see Molality for the physical quantity represented by this unit.
+ */
+typealias MolPerKilogram = Quotient<Mol, Kilogram>
+
+/**
+ * Represents the physical quantity of **molality**.
+ *
+ * Molality quantifies the **amount of substance of solute per unit mass of solvent**.
+ * Unlike molarity, it does not depend on volume (and therefore is unaffected by temperature
+ * or pressure changes), making it particularly useful in thermodynamic calculations.
+ * Its SI unit is the **mole per kilogram (mol/kg)**, represented here by [MolPerKilogram].
+ *
+ * Example usages include:
+ * - Expressing the concentration of a solute in a solution
+ * - Thermodynamic property calculations (e.g., colligative properties)
+ * - Chemistry and chemical engineering applications
+ *
+ * The magnitude is stored as a [BigDecimal] to ensure high precision.
+ * Instances of [Molality] are immutable, and the [expression] parameter ties
+ * the measurement to its unit representation ([MolPerKilogram]).
+ *
+ * @property magnitude The numeric value of the molality.
+ * @property expression The unit expression of the molality, always [MolPerKilogram].
+ */
+class Molality(
+    magnitude: BigDecimal,
+    expression: MolPerKilogram
+) : Measure<MolPerKilogram, Molality>(magnitude, expression, ::Molality)

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/MolarConductivity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/MolarConductivity.kt
@@ -1,0 +1,53 @@
+package org.kisu.units.chemistry
+
+import org.kisu.units.Measure
+import org.kisu.units.base.Mol
+import org.kisu.units.representation.Product
+import org.kisu.units.representation.Quotient
+import org.kisu.units.special.Siemens
+import org.kisu.units.special.SquareMetre
+import java.math.BigDecimal
+
+/**
+ * Represents the SI unit **siemens square metre per mole (S·m²/mol)**.
+ *
+ * This unit is used to measure **molar conductivity**, i.e., the electrical
+ * conductivity of an electrolyte solution normalized by its molar concentration.
+ * It is defined as the [Quotient] of the [Product] of [Siemens] (conductance) and
+ * [SquareMetre] (area) divided by [Mol] (amount of substance).
+ *
+ * Example usages include:
+ * - Determining ion mobility in electrolyte solutions
+ * - Characterising strong and weak electrolytes
+ * - Electrochemistry and materials science applications
+ *
+ * @see MolarConductivity for the physical quantity represented by this unit.
+ */
+typealias SiemesSquareMetrePerMole = Quotient<Product<Siemens, SquareMetre>, Mol>
+
+/**
+ * Represents the physical quantity of **molar conductivity**.
+ *
+ * Molar conductivity quantifies the **conductivity of an electrolyte solution,
+ * normalized by its molar concentration**.
+ * It indicates how effectively ions contribute to electrical conduction on a
+ * per-mole basis.
+ * Its SI unit is the **siemens square metre per mole (S·m²/mol)**, represented here
+ * by [SiemesSquareMetrePerMole].
+ *
+ * Example usages include:
+ * - Determining ion mobility in electrolyte solutions
+ * - Characterising strong and weak electrolytes
+ * - Applications in electrochemistry and materials science
+ *
+ * The magnitude is stored as a [BigDecimal] to ensure high precision.
+ * Instances of [MolarConductivity] are immutable, and the [expression] parameter ties
+ * the measurement to its unit representation ([SiemesSquareMetrePerMole]).
+ *
+ * @property magnitude The numeric value of the molar conductivity.
+ * @property expression The unit expression of the molar conductivity, always [SiemesSquareMetrePerMole].
+ */
+class MolarConductivity(
+    magnitude: BigDecimal,
+    expression: SiemesSquareMetrePerMole
+) : Measure<SiemesSquareMetrePerMole, MolarConductivity>(magnitude, expression, ::MolarConductivity)

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/MolarEnergy.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/MolarEnergy.kt
@@ -1,0 +1,48 @@
+package org.kisu.units.chemistry
+
+import org.kisu.units.Measure
+import org.kisu.units.base.Mol
+import org.kisu.units.representation.Quotient
+import org.kisu.units.special.Joule
+import java.math.BigDecimal
+
+/**
+ * Represents the SI unit **joule per mole (J/mol)**.
+ *
+ * This unit measures **molar energy**, i.e., the amount of energy associated
+ * with one mole of a substance.
+ * It is defined as the [Quotient] of [Joule] (energy) divided by [Mol] (amount of substance).
+ *
+ * Example usages include:
+ * - Enthalpy of reaction (ΔH, in J/mol)
+ * - Gibbs free energy (ΔG, in J/mol)
+ * - Energy per mole for phase transitions or chemical reactions
+ *
+ * @see MolarEnergy for the physical quantity represented by this unit.
+ */
+typealias JoulePerMole = Quotient<Joule, Mol>
+
+/**
+ * Represents the physical quantity of **molar energy**.
+ *
+ * Molar energy quantifies the **amount of energy per mole of substance**.
+ * It is commonly used in thermodynamics and chemistry to describe the energy
+ * content or energy change associated with chemical reactions or phase transitions.
+ * Its SI unit is the **joule per mole (J/mol)**, represented here by [JoulePerMole].
+ *
+ * Example usages include:
+ * - Enthalpy of reaction (ΔH, in J/mol)
+ * - Gibbs free energy of formation (ΔG, in J/mol)
+ * - Energy per mole in phase changes (e.g., vaporization, fusion)
+ *
+ * The magnitude is stored as a [BigDecimal] to ensure high precision.
+ * Instances of [MolarEnergy] are immutable, and the [expression] parameter ties
+ * the measurement to its unit representation ([JoulePerMole]).
+ *
+ * @property magnitude The numeric value of the molar energy.
+ * @property expression The unit expression of the molar energy, always [JoulePerMole].
+ */
+class MolarEnergy(
+    magnitude: BigDecimal,
+    expression: JoulePerMole
+) : Measure<JoulePerMole, MolarEnergy>(magnitude, expression, ::MolarEnergy)

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/MolarHeatCapacity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/MolarHeatCapacity.kt
@@ -1,0 +1,49 @@
+package org.kisu.units.chemistry
+
+import org.kisu.units.Measure
+import org.kisu.units.base.Kelvin
+import org.kisu.units.base.Mol
+import org.kisu.units.representation.Product
+import org.kisu.units.representation.Quotient
+import org.kisu.units.special.Joule
+import java.math.BigDecimal
+
+/**
+ * Represents the SI unit **joule per kelvin mole (J/(K·mol))**.
+ *
+ * This unit measures **molar heat capacity**, i.e., the amount of heat required
+ * to raise the temperature of one mole of a substance by one kelvin.
+ * It is defined as the [Quotient] of [Joule] (energy) divided by the [Product] of
+ * [Kelvin] (temperature) and [Mol] (amount of substance).
+ *
+ * Example usages include:
+ * - Determining the molar heat capacity of water (~75.3 J/(K·mol))
+ * - Thermodynamic calculations in chemistry and materials science
+ * - Analyzing energy changes per mole during temperature variations
+ *
+ * @see MolarHeatCapacity for the physical quantity represented by this unit.
+ */
+typealias JoulePerKelvinMole = Quotient<Joule, Product<Kelvin, Mol>>
+
+/**
+ * Represents the **molar heat capacity** of a substance.
+ *
+ * Molar heat capacity is the amount of heat required to raise the temperature
+ * of one mole of a substance by one kelvin. It combines energy, temperature,
+ * and amount of substance into a single quantity.
+ *
+ * Expressed in **joules per kelvin mole (J·K⁻¹·mol⁻¹)**.
+ *
+ * ## Example
+ * The molar heat capacity of liquid water at room temperature is approximately
+ * **75.3 J·K⁻¹·mol⁻¹**, meaning it takes 75.3 joules of energy to increase the
+ * temperature of one mole of water by one kelvin.
+ *
+ * @constructor Creates a [MolarHeatCapacity] with the given [magnitude] and [expression].
+ * @property magnitude Numerical value of the molar heat capacity.
+ * @property expression The unit expression, [JoulePerKelvinMole].
+ */
+class MolarHeatCapacity(
+    magnitude: BigDecimal,
+    expression: JoulePerKelvinMole
+) : Measure<JoulePerKelvinMole, MolarHeatCapacity>(magnitude, expression, ::MolarHeatCapacity)

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/MolarMass.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/MolarMass.kt
@@ -1,0 +1,45 @@
+package org.kisu.units.chemistry
+
+import org.kisu.units.Measure
+import org.kisu.units.base.Kilogram
+import org.kisu.units.base.Mol
+import org.kisu.units.representation.Quotient
+import java.math.BigDecimal
+
+/**
+ * Represents the SI unit **kilogram per mole (kg/mol)**.
+ *
+ * This unit measures **molar mass**, i.e., the mass of one mole of a substance.
+ * It is defined as the [Quotient] of [Kilogram] (mass) divided by [Mol] (amount of substance).
+ *
+ * Example usages include:
+ * - Determining the mass of one mole of water (~0.018 kg/mol)
+ * - Stoichiometric calculations in chemical reactions
+ * - Molecular and thermodynamic property analyses
+ *
+ * @see MolarMass for the physical quantity represented by this unit.
+ */
+typealias KilogramPerMole = Quotient<Kilogram, Mol>
+
+/**
+ * Represents the physical quantity of **molar mass**.
+ *
+ * Molar mass quantifies the **mass of one mole of a substance**.
+ * Its SI unit is the **kilogram per mole (kg/mol)**, represented here by [KilogramPerMole].
+ *
+ * Example usages include:
+ * - Calculating the mass of a given number of moles of a substance
+ * - Determining stoichiometric ratios in chemical reactions
+ * - Molecular property and thermodynamic calculations
+ *
+ * The magnitude is stored as a [BigDecimal] to ensure high precision.
+ * Instances of [MolarMass] are immutable, and the [expression] parameter ties the measurement
+ * to its unit representation ([KilogramPerMole]).
+ *
+ * @property magnitude The numeric value of the molar mass.
+ * @property expression The unit expression of the molar mass, always [KilogramPerMole].
+ */
+class MolarMass(
+    magnitude: BigDecimal,
+    expression: KilogramPerMole
+) : Measure<KilogramPerMole, MolarMass>(magnitude, expression, ::MolarMass)

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/MolarVolume.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/MolarVolume.kt
@@ -1,0 +1,46 @@
+package org.kisu.units.chemistry
+
+import org.kisu.units.Measure
+import org.kisu.units.base.Mol
+import org.kisu.units.representation.Quotient
+import org.kisu.units.special.CubicMetre
+import java.math.BigDecimal
+
+/**
+ * Represents the SI unit **cubic metre per mole (m³/mol)**.
+ *
+ * This unit measures **molar volume**, i.e., the volume occupied by one mole
+ * of a substance.
+ * It is defined as the [Quotient] of [CubicMetre] (volume) divided by [Mol] (amount of substance).
+ *
+ * Example usages include:
+ * - Calculating the volume of gases using the ideal gas law
+ * - Determining molar volumes of liquids and solids
+ * - Chemical and thermodynamic calculations
+ *
+ * @see MolarVolume for the physical quantity represented by this unit.
+ */
+typealias CubicMetrePerMole = Quotient<CubicMetre, Mol>
+
+/**
+ * Represents the physical quantity of **molar volume**.
+ *
+ * Molar volume quantifies the **volume occupied by one mole of a substance**.
+ * Its SI unit is the **cubic metre per mole (m³/mol)**, represented here by [CubicMetrePerMole].
+ *
+ * Example usages include:
+ * - Calculating the volume of gases using the ideal gas law
+ * - Determining molar volumes of liquids and solids
+ * - Chemical and thermodynamic calculations
+ *
+ * The magnitude is stored as a [BigDecimal] to ensure high precision.
+ * Instances of [MolarVolume] are immutable, and the [expression] parameter ties the measurement
+ * to its unit representation ([CubicMetrePerMole]).
+ *
+ * @property magnitude The numeric value of the molar volume.
+ * @property expression The unit expression of the molar volume, always [CubicMetrePerMole].
+ */
+class MolarVolume(
+    magnitude: BigDecimal,
+    expression: CubicMetrePerMole
+) : Measure<CubicMetrePerMole, MolarVolume>(magnitude, expression, ::MolarVolume)

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/Molarity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/Molarity.kt
@@ -1,0 +1,45 @@
+package org.kisu.units.chemistry
+
+import org.kisu.units.Measure
+import org.kisu.units.base.Mol
+import org.kisu.units.representation.Quotient
+import org.kisu.units.special.CubicMetre
+import java.math.BigDecimal
+
+/**
+ * Represents the SI unit **mole per cubic metre (mol/m³)**.
+ *
+ * This unit measures **molarity**, i.e., the number of moles of a substance
+ * present in a unit volume of solution.
+ * It is defined as the [Quotient] of [Mol] (amount of substance) divided by [CubicMetre] (volume).
+ *
+ * Example usages include:
+ * - Expressing the concentration of a solution in chemistry and chemical engineering
+ * - Calculating reactant availability in volumetric reactions
+ * - Thermodynamic and solution property analyses
+ *
+ * @see Molarity for the physical quantity represented by this unit.
+ */
+typealias MolePerCubicMetre = Quotient<Mol, CubicMetre>
+
+/**
+ * Represents the **molarity** (also called **molar concentration**) of a solution.
+ *
+ * Molarity is the number of moles of solute present in one cubic metre of solution.
+ * It expresses how concentrated a substance is within a given volume of solvent.
+ *
+ * Expressed in **moles per cubic metre (mol·m⁻³)**.
+ *
+ * ## Example
+ * A typical laboratory solution of sodium chloride (NaCl) might have a molarity of
+ * **1000 mol·m⁻³**, which is equivalent to a 1 mol/L solution. This means the solution
+ * contains one mole of NaCl dissolved in each litre of water.
+ *
+ * @constructor Creates a [Molarity] with the given [magnitude] and [expression].
+ * @property magnitude Numerical value of the molarity.
+ * @property expression The unit expression, [MolePerCubicMetre].
+ */
+class Molarity(
+    magnitude: BigDecimal,
+    expression: MolePerCubicMetre
+) : Measure<MolePerCubicMetre, Molarity>(magnitude, expression, ::Molarity)


### PR DESCRIPTION
Closes #73 
  
## 🐞 Problem to Solve

This PR introduces **SI derived units commonly used in Chemistry** to the KISU library. These units complement the existing SI units for mechanics, thermodynamics, and electromagnetism, enabling richer modeling of chemical and physical systems.

## 💡 Solution

## Units Added

- **Molarity** (`mol/m³`) – Amount of substance per unit volume.  
- **Molar Mass** (`kg/mol`) – Mass per mole of substance.  
- **Molar Volume** (`m³/mol`) – Volume per mole of substance.  
- **Mass Concentration** (`kg/m³`) – Mass of substance per unit volume.  
- **Volume Fraction** (`m³/m³`) – Volume fraction, dimensionless but used in chemical context.  
- **Molality** (`mol/kg`) – Amount of substance per unit mass of solvent.  
- **Catalytic Activity Concentration** (`kat/m³`) – Catalytic activity per unit volume.

Each unit is implemented as a `typealias` using `Quotient`, `Product`, or `Scalar` types, following the naming conventions of the library. KDoc documentation is included for each type, and unit tests have been added to validate conversions and relationships.

---
  
  ✅ **Checklist**

- [X] The PR includes a clear and descriptive title
- [X] Related issue(s) are linked in the PR body
- [X] The solution is explained thoroughly
- [X] Tests or proofs are included

