### PR TITLE
[KISU-79] Corrects the typo of "Mol" to "Mole"

### DIFF
--- a/lib/src/main/kotlin/org/kisu/units/base/Amount.kt
+++ b/lib/src/main/kotlin/org/kisu/units/base/Amount.kt
@@ -23,11 +23,11 @@ import java.math.BigDecimal
  *
  * Instances of this class are immutable and preserve their precision using [BigDecimal].
  */
-class Amount internal constructor(magnitude: BigDecimal, expression: Mol) :
-    Measure<Mol, Amount>(magnitude, expression, ::Amount) {
+class Amount internal constructor(magnitude: BigDecimal, expression: Mole) :
+    Measure<Mole, Amount>(magnitude, expression, ::Amount) {
 
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
-        this(magnitude, Mol(prefix))
+        this(magnitude, Mole(prefix))
 
     companion object {
         /**
@@ -40,11 +40,11 @@ class Amount internal constructor(magnitude: BigDecimal, expression: Mol) :
     }
 }
 
-class Mol private constructor(
+class Mole private constructor(
     prefix: Metric,
     overflow: BigDecimal = BigDecimal.ONE,
     unit: Unit,
-) : Scalar<Metric, Mol>(prefix, overflow, unit, ::Mol) {
+) : Scalar<Metric, Mole>(prefix, overflow, unit, ::Mole) {
 
     constructor(prefix: Metric = Metric.BASE) : this(prefix, BigDecimal.ONE, UNIT)
 

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/CatalyticEfficiency.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/CatalyticEfficiency.kt
@@ -1,7 +1,7 @@
 package org.kisu.units.chemistry
 
 import org.kisu.units.Measure
-import org.kisu.units.base.Mol
+import org.kisu.units.base.Mole
 import org.kisu.units.base.Second
 import org.kisu.units.representation.Product
 import org.kisu.units.representation.Quotient
@@ -14,7 +14,7 @@ import java.math.BigDecimal
  * This unit is used to measure **catalytic efficiency**, i.e., the volume of
  * substrate converted per mole of catalyst per second.
  * It is defined as the [Quotient] of [SquareMetre] (area) divided by the [Product]
- * of [Mol] (amount of substance) and [Second] (time).
+ * of [Mole] (amount of substance) and [Second] (time).
  *
  * Example usages include:
  * - Characterising enzyme or catalyst performance in chemical reactions
@@ -22,7 +22,7 @@ import java.math.BigDecimal
  *
  * @see CatalyticEfficiency for the physical quantity represented by this unit.
  */
-typealias CubicMetrePerMoleSecond = Quotient<SquareMetre, Product<Mol, Second>>
+typealias CubicMetrePerMoleSecond = Quotient<SquareMetre, Product<Mole, Second>>
 
 /**
  * Represents the physical quantity of **catalytic efficiency**.

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/Molality.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/Molality.kt
@@ -2,7 +2,7 @@ package org.kisu.units.chemistry
 
 import org.kisu.units.Measure
 import org.kisu.units.base.Kilogram
-import org.kisu.units.base.Mol
+import org.kisu.units.base.Mole
 import org.kisu.units.representation.Quotient
 import java.math.BigDecimal
 
@@ -11,7 +11,7 @@ import java.math.BigDecimal
  *
  * This unit measures **molality**, i.e., the amount of substance per unit mass
  * of solvent.
- * It is defined as the [Quotient] of [Mol] (amount of substance) divided by [Kilogram] (mass).
+ * It is defined as the [Quotient] of [Mole] (amount of substance) divided by [Kilogram] (mass).
  *
  * Example usages include:
  * - Expressing solute concentration in chemistry and chemical engineering
@@ -19,7 +19,7 @@ import java.math.BigDecimal
  *
  * @see Molality for the physical quantity represented by this unit.
  */
-typealias MolPerKilogram = Quotient<Mol, Kilogram>
+typealias MolPerKilogram = Quotient<Mole, Kilogram>
 
 /**
  * Represents the physical quantity of **molality**.

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/MolarConductivity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/MolarConductivity.kt
@@ -1,7 +1,7 @@
 package org.kisu.units.chemistry
 
 import org.kisu.units.Measure
-import org.kisu.units.base.Mol
+import org.kisu.units.base.Mole
 import org.kisu.units.representation.Product
 import org.kisu.units.representation.Quotient
 import org.kisu.units.special.Siemens
@@ -14,7 +14,7 @@ import java.math.BigDecimal
  * This unit is used to measure **molar conductivity**, i.e., the electrical
  * conductivity of an electrolyte solution normalized by its molar concentration.
  * It is defined as the [Quotient] of the [Product] of [Siemens] (conductance) and
- * [SquareMetre] (area) divided by [Mol] (amount of substance).
+ * [SquareMetre] (area) divided by [Mole] (amount of substance).
  *
  * Example usages include:
  * - Determining ion mobility in electrolyte solutions
@@ -23,7 +23,7 @@ import java.math.BigDecimal
  *
  * @see MolarConductivity for the physical quantity represented by this unit.
  */
-typealias SiemesSquareMetrePerMole = Quotient<Product<Siemens, SquareMetre>, Mol>
+typealias SiemesSquareMetrePerMole = Quotient<Product<Siemens, SquareMetre>, Mole>
 
 /**
  * Represents the physical quantity of **molar conductivity**.

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/MolarEnergy.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/MolarEnergy.kt
@@ -1,7 +1,7 @@
 package org.kisu.units.chemistry
 
 import org.kisu.units.Measure
-import org.kisu.units.base.Mol
+import org.kisu.units.base.Mole
 import org.kisu.units.representation.Quotient
 import org.kisu.units.special.Joule
 import java.math.BigDecimal
@@ -11,7 +11,7 @@ import java.math.BigDecimal
  *
  * This unit measures **molar energy**, i.e., the amount of energy associated
  * with one mole of a substance.
- * It is defined as the [Quotient] of [Joule] (energy) divided by [Mol] (amount of substance).
+ * It is defined as the [Quotient] of [Joule] (energy) divided by [Mole] (amount of substance).
  *
  * Example usages include:
  * - Enthalpy of reaction (ΔH, in J/mol)
@@ -20,7 +20,7 @@ import java.math.BigDecimal
  *
  * @see MolarEnergy for the physical quantity represented by this unit.
  */
-typealias JoulePerMole = Quotient<Joule, Mol>
+typealias JoulePerMole = Quotient<Joule, Mole>
 
 /**
  * Represents the physical quantity of **molar energy**.

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/MolarHeatCapacity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/MolarHeatCapacity.kt
@@ -2,7 +2,7 @@ package org.kisu.units.chemistry
 
 import org.kisu.units.Measure
 import org.kisu.units.base.Kelvin
-import org.kisu.units.base.Mol
+import org.kisu.units.base.Mole
 import org.kisu.units.representation.Product
 import org.kisu.units.representation.Quotient
 import org.kisu.units.special.Joule
@@ -14,7 +14,7 @@ import java.math.BigDecimal
  * This unit measures **molar heat capacity**, i.e., the amount of heat required
  * to raise the temperature of one mole of a substance by one kelvin.
  * It is defined as the [Quotient] of [Joule] (energy) divided by the [Product] of
- * [Kelvin] (temperature) and [Mol] (amount of substance).
+ * [Kelvin] (temperature) and [Mole] (amount of substance).
  *
  * Example usages include:
  * - Determining the molar heat capacity of water (~75.3 J/(K·mol))
@@ -23,7 +23,7 @@ import java.math.BigDecimal
  *
  * @see MolarHeatCapacity for the physical quantity represented by this unit.
  */
-typealias JoulePerKelvinMole = Quotient<Joule, Product<Kelvin, Mol>>
+typealias JoulePerKelvinMole = Quotient<Joule, Product<Kelvin, Mole>>
 
 /**
  * Represents the **molar heat capacity** of a substance.

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/MolarMass.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/MolarMass.kt
@@ -2,7 +2,7 @@ package org.kisu.units.chemistry
 
 import org.kisu.units.Measure
 import org.kisu.units.base.Kilogram
-import org.kisu.units.base.Mol
+import org.kisu.units.base.Mole
 import org.kisu.units.representation.Quotient
 import java.math.BigDecimal
 
@@ -10,7 +10,7 @@ import java.math.BigDecimal
  * Represents the SI unit **kilogram per mole (kg/mol)**.
  *
  * This unit measures **molar mass**, i.e., the mass of one mole of a substance.
- * It is defined as the [Quotient] of [Kilogram] (mass) divided by [Mol] (amount of substance).
+ * It is defined as the [Quotient] of [Kilogram] (mass) divided by [Mole] (amount of substance).
  *
  * Example usages include:
  * - Determining the mass of one mole of water (~0.018 kg/mol)
@@ -19,7 +19,7 @@ import java.math.BigDecimal
  *
  * @see MolarMass for the physical quantity represented by this unit.
  */
-typealias KilogramPerMole = Quotient<Kilogram, Mol>
+typealias KilogramPerMole = Quotient<Kilogram, Mole>
 
 /**
  * Represents the physical quantity of **molar mass**.

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/MolarVolume.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/MolarVolume.kt
@@ -1,7 +1,7 @@
 package org.kisu.units.chemistry
 
 import org.kisu.units.Measure
-import org.kisu.units.base.Mol
+import org.kisu.units.base.Mole
 import org.kisu.units.representation.Quotient
 import org.kisu.units.special.CubicMetre
 import java.math.BigDecimal
@@ -11,7 +11,7 @@ import java.math.BigDecimal
  *
  * This unit measures **molar volume**, i.e., the volume occupied by one mole
  * of a substance.
- * It is defined as the [Quotient] of [CubicMetre] (volume) divided by [Mol] (amount of substance).
+ * It is defined as the [Quotient] of [CubicMetre] (volume) divided by [Mole] (amount of substance).
  *
  * Example usages include:
  * - Calculating the volume of gases using the ideal gas law
@@ -20,7 +20,7 @@ import java.math.BigDecimal
  *
  * @see MolarVolume for the physical quantity represented by this unit.
  */
-typealias CubicMetrePerMole = Quotient<CubicMetre, Mol>
+typealias CubicMetrePerMole = Quotient<CubicMetre, Mole>
 
 /**
  * Represents the physical quantity of **molar volume**.

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/Molarity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/Molarity.kt
@@ -1,7 +1,7 @@
 package org.kisu.units.chemistry
 
 import org.kisu.units.Measure
-import org.kisu.units.base.Mol
+import org.kisu.units.base.Mole
 import org.kisu.units.representation.Quotient
 import org.kisu.units.special.CubicMetre
 import java.math.BigDecimal
@@ -11,7 +11,7 @@ import java.math.BigDecimal
  *
  * This unit measures **molarity**, i.e., the number of moles of a substance
  * present in a unit volume of solution.
- * It is defined as the [Quotient] of [Mol] (amount of substance) divided by [CubicMetre] (volume).
+ * It is defined as the [Quotient] of [Mole] (amount of substance) divided by [CubicMetre] (volume).
  *
  * Example usages include:
  * - Expressing the concentration of a solution in chemistry and chemical engineering
@@ -20,7 +20,7 @@ import java.math.BigDecimal
  *
  * @see Molarity for the physical quantity represented by this unit.
  */
-typealias MolePerCubicMetre = Quotient<Mol, CubicMetre>
+typealias MolePerCubicMetre = Quotient<Mole, CubicMetre>
 
 /**
  * Represents the **molarity** (also called **molar concentration**) of a solution.

--- a/lib/src/main/kotlin/org/kisu/units/representation/Unit.kt
+++ b/lib/src/main/kotlin/org/kisu/units/representation/Unit.kt
@@ -5,7 +5,7 @@ import org.kisu.units.base.Candela
 import org.kisu.units.base.Kelvin
 import org.kisu.units.base.Kilogram
 import org.kisu.units.base.Metre
-import org.kisu.units.base.Mol
+import org.kisu.units.base.Mole
 import org.kisu.units.base.Second
 import org.kisu.units.special.Becquerel
 import org.kisu.units.special.Coulomb
@@ -228,7 +228,7 @@ internal val CANONICAL_ORDER: List<Unit> = listOf(
     Second.UNIT,
     Ampere.UNIT,
     Kelvin.UNIT,
-    Mol.UNIT,
+    Mole.UNIT,
     Candela.UNIT,
     Radian.UNIT,
     Steradian.UNIT

--- a/lib/src/test/kotlin/org/kisu/test/generators/Units.kt
+++ b/lib/src/test/kotlin/org/kisu/test/generators/Units.kt
@@ -12,7 +12,7 @@ import org.kisu.units.base.Candela
 import org.kisu.units.base.Kelvin
 import org.kisu.units.base.Kilogram
 import org.kisu.units.base.Metre
-import org.kisu.units.base.Mol
+import org.kisu.units.base.Mole
 import org.kisu.units.base.Second
 import org.kisu.units.representation.Scalar
 import org.kisu.units.special.Becquerel
@@ -89,7 +89,7 @@ private val METRIC_UNITS: List<(Metric) -> Scalar<Metric, *>> = listOf(
     ::Second,
     ::Ampere,
     ::Kelvin,
-    ::Mol,
+    ::Mole,
     ::Candela,
     ::Radian,
     ::Steradian

--- a/lib/src/test/kotlin/org/kisu/units/base/AmountTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/base/AmountTest.kt
@@ -15,8 +15,8 @@ class AmountTest : StringSpec({
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().moles.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe Mol(magnitude.builder().metric)
-                symbol shouldBe Mol.UNIT.toString()
+                expression shouldBe Mole(magnitude.builder().metric)
+                symbol shouldBe Mole.UNIT.toString()
             }
         }
     }
@@ -25,8 +25,8 @@ class AmountTest : StringSpec({
         checkAll(Arb.bigDecimal()) { magnitude ->
             magnitude.moles.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe Mol()
-                symbol shouldBe Mol.UNIT.toString()
+                expression shouldBe Mole()
+                symbol shouldBe Mole.UNIT.toString()
             }
         }
     }


### PR DESCRIPTION
Closes #79 
  
## 🐞 Problem to Solve

The name "Mol" was used for "Mole".

## 💡 Solution

Renamed the class.

---
  
  ✅ **Checklist**

- [X] The PR includes a clear and descriptive title
- [X] Related issue(s) are linked in the PR body
- [X] The solution is explained thoroughly
- [X] Tests or proofs are included

