### PR TITLE
Bumps and updates configuration

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 kotlin.code.style=official
+org.gradle.configuration-cache=true
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ detekt = "1.23.8"
 dokka = "2.0.0"
 jacoco = "0.8.13"
 klint = "12.3.0"
-kotest = "5.9.1"
+kotest = "6.0.0"
 
 [plugins]
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt"}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/lib/src/test/kotlin/io/kotest/provided/ProjectConfig.kt
+++ b/lib/src/test/kotlin/io/kotest/provided/ProjectConfig.kt
@@ -1,0 +1,10 @@
+package io.kotest.provided
+
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.engine.concurrency.SpecExecutionMode
+import io.kotest.engine.concurrency.TestExecutionMode
+
+object ProjectConfig : AbstractProjectConfig() {
+    override val specExecutionMode = SpecExecutionMode.Concurrent
+    override val testExecutionMode = TestExecutionMode.Concurrent
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,7 +4,7 @@ pluginManagement {
         mavenCentral()
     }
     plugins {
-        id("org.jetbrains.kotlin.jvm") version "2.2.0"
+        id("org.jetbrains.kotlin.jvm") version "2.2.10"
     }
 }
 


### PR DESCRIPTION
Closes #81 
  
## 🐞 Problem to Solve

Updates dependencies

## 💡 Solution

- Bumped Kotlin to 2.2.10
- Bumped Gradle to 9.0
- Bumped Kotest to 6.0

Also added Concurrency capabilities for Kotest and Gradle configuration cache.


---
  
  ✅ **Checklist**

- [X] The PR includes a clear and descriptive title
- [X] Related issue(s) are linked in the PR body
- [x] The solution is explained thoroughly
- [X] Tests or proofs are included

