### PR TITLE
[KISU-83] Creates Metric builders for derived units

### DIFF
--- a/lib/src/main/kotlin/org/kisu/units/base/Mass.kt
+++ b/lib/src/main/kotlin/org/kisu/units/base/Mass.kt
@@ -25,7 +25,7 @@ import java.math.BigDecimal
 class Mass internal constructor(magnitude: BigDecimal, expression: Kilogram) :
     Measure<Kilogram, Mass>(magnitude, expression, ::Mass) {
 
-    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.KILO) :
         this(magnitude, Kilogram(prefix))
 }
 
@@ -44,6 +44,6 @@ class Kilogram private constructor(
 
     companion object {
         /** The canonical SI symbol for mass: "kg". */
-        internal val UNIT = Unit("kg", 1)
+        internal val UNIT = Unit("g", 1)
     }
 }

--- a/lib/src/main/kotlin/org/kisu/units/builders/MetricUnitBuilder.kt
+++ b/lib/src/main/kotlin/org/kisu/units/builders/MetricUnitBuilder.kt
@@ -8,6 +8,8 @@ import org.kisu.units.base.LuminousIntensity
 import org.kisu.units.base.Mass
 import org.kisu.units.base.Temperature
 import org.kisu.units.base.Time
+import org.kisu.units.electromagnetic.MagneticReluctance
+import org.kisu.units.mechanics.Compressibility
 import org.kisu.units.special.AbsorbedDose
 import org.kisu.units.special.Area
 import org.kisu.units.special.Capacitance
@@ -32,6 +34,7 @@ import org.kisu.units.special.Radioactivity
 import org.kisu.units.special.Resistance
 import org.kisu.units.special.SolidAngle
 import org.kisu.units.special.Volume
+import org.kisu.units.thermodynamics.ThermalExpansionCoefficient
 import java.math.BigDecimal
 
 /**
@@ -114,10 +117,10 @@ val MetricUnitBuilder.coulombs: ElectricCharge get() = ElectricCharge(magnitude,
  *
  * Example usage:
  * ```
- * val v = 2.kilo.cubicMeters // 2 * 10^3 cubic metres
+ * val v = 2.kilo.cubicMetres // 2 * 10^3 cubic metres
  * ```
  */
-val MetricUnitBuilder.cubicMeters: Volume get() = Volume(magnitude, metric)
+val MetricUnitBuilder.cubicMetres: Volume get() = Volume(magnitude, metric)
 
 /**
  * Creates a [Capacitance] measure by applying the metric prefix scale to the magnitude.
@@ -226,10 +229,10 @@ val MetricUnitBuilder.lux: Illuminance get() = Illuminance(magnitude, metric)
  *
  * Example usage:
  * ```
- * val length = 25.kilo.meters // 25 * 10^3 meters
+ * val length = 25.kilo.metres // 25 * 10^3 metres
  * ```
  */
-val MetricUnitBuilder.meters: Length get() = Length(magnitude, metric)
+val MetricUnitBuilder.metres: Length get() = Length(magnitude, metric)
 
 /**
  * Creates an [Amount] measure by applying the metric prefix scale to the magnitude.
@@ -282,6 +285,39 @@ val MetricUnitBuilder.pascals: Pressure get() = Pressure(magnitude, metric)
 val MetricUnitBuilder.radians: PlaneAngle get() = PlaneAngle(magnitude, metric)
 
 /**
+ * Creates a [MagneticReluctance] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val reluctance = 5.kilo.reciprocalHenries // 5 * 10^3 H⁻¹
+ * ```
+ */
+val MetricUnitBuilder.reciprocalHenries: MagneticReluctance
+    get() = MagneticReluctance(magnitude, metric)
+
+/**
+ * Creates a [ThermalExpansionCoefficient] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val coefficient = 2.milli.reciprocalKelvins // 2 * 10^-3 K⁻¹
+ * ```
+ */
+val MetricUnitBuilder.reciprocalKelvins: ThermalExpansionCoefficient
+    get() = ThermalExpansionCoefficient(magnitude, metric)
+
+/**
+ * Creates a [Compressibility] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val compressibility = 7.micro.reciprocalPascal // 7 * 10^-6 Pa⁻¹
+ * ```
+ */
+val MetricUnitBuilder.reciprocalPascal: Compressibility
+    get() = Compressibility(magnitude, metric)
+
+/**
  * Creates a [Time] measure by applying the metric prefix scale to the magnitude.
  *
  * Example usage:
@@ -316,10 +352,10 @@ val MetricUnitBuilder.sieverts: DoseEquivalent get() = DoseEquivalent(magnitude,
  *
  * Example usage:
  * ```
- * val a = 5.centi.squareMeters // 5 * 10^-2 square metres
+ * val a = 5.centi.squareMetres // 5 * 10^-2 square metres
  * ```
  */
-val MetricUnitBuilder.squareMeters: Area get() = Area(magnitude, metric)
+val MetricUnitBuilder.squareMetres: Area get() = Area(magnitude, metric)
 
 /**
  * Creates a [SolidAngle] measure by applying the metric prefix scale to the magnitude.

--- a/lib/src/main/kotlin/org/kisu/units/builders/MetricUnitBuilder.kt
+++ b/lib/src/main/kotlin/org/kisu/units/builders/MetricUnitBuilder.kt
@@ -8,8 +8,73 @@ import org.kisu.units.base.LuminousIntensity
 import org.kisu.units.base.Mass
 import org.kisu.units.base.Temperature
 import org.kisu.units.base.Time
+import org.kisu.units.chemistry.CatalyticEfficiency
+import org.kisu.units.chemistry.Molality
+import org.kisu.units.chemistry.MolarConductivity
+import org.kisu.units.chemistry.MolarEnergy
+import org.kisu.units.chemistry.MolarHeatCapacity
+import org.kisu.units.chemistry.MolarMass
+import org.kisu.units.chemistry.MolarVolume
+import org.kisu.units.chemistry.Molarity
+import org.kisu.units.electromagnetic.ElectricChargeDensity
+import org.kisu.units.electromagnetic.ElectricConductivity
+import org.kisu.units.electromagnetic.ElectricCurrentDensity
+import org.kisu.units.electromagnetic.ElectricDisplacementField
+import org.kisu.units.electromagnetic.ElectricFieldStrength
+import org.kisu.units.electromagnetic.ElectronMobility
+import org.kisu.units.electromagnetic.Exposure
+import org.kisu.units.electromagnetic.LinearChargeDensity
+import org.kisu.units.electromagnetic.MagneticDipoleMoment
+import org.kisu.units.electromagnetic.MagneticMoment
+import org.kisu.units.electromagnetic.MagneticPermittivity
 import org.kisu.units.electromagnetic.MagneticReluctance
+import org.kisu.units.electromagnetic.MagneticRigidity
+import org.kisu.units.electromagnetic.MagneticSusceptibility
+import org.kisu.units.electromagnetic.MagneticVectorPotential
+import org.kisu.units.electromagnetic.Magnetization
+import org.kisu.units.electromagnetic.MagnetomotiveForce
+import org.kisu.units.electromagnetic.Permittivity
+import org.kisu.units.electromagnetic.Resistivity
+import org.kisu.units.kinematics.FrequencyDrift
+import org.kisu.units.kinematics.VolumetricFlow
+import org.kisu.units.kinematics.Yank
+import org.kisu.units.kinematics.angular.Velocity
+import org.kisu.units.kinematics.linear.Acceleration
+import org.kisu.units.kinematics.linear.Crackle
+import org.kisu.units.kinematics.linear.Jerk
+import org.kisu.units.kinematics.linear.Pop
+import org.kisu.units.kinematics.linear.Snap
+import org.kisu.units.kinematics.linear.Speed
+import org.kisu.units.mechanics.AbsorbedDoseRate
+import org.kisu.units.mechanics.Action
+import org.kisu.units.mechanics.AngularMomentum
+import org.kisu.units.mechanics.AreaDensity
 import org.kisu.units.mechanics.Compressibility
+import org.kisu.units.mechanics.Density
+import org.kisu.units.mechanics.DynamicViscosity
+import org.kisu.units.mechanics.EnergyDensity
+import org.kisu.units.mechanics.EnergyFluxDensity
+import org.kisu.units.mechanics.FuelEfficiency
+import org.kisu.units.mechanics.HeatFluxDensity
+import org.kisu.units.mechanics.KinematicViscosity
+import org.kisu.units.mechanics.LinearMassDensity
+import org.kisu.units.mechanics.MassFlowRate
+import org.kisu.units.mechanics.MomentOfIntertia
+import org.kisu.units.mechanics.Momentum
+import org.kisu.units.mechanics.Radiance
+import org.kisu.units.mechanics.RadiantExposure
+import org.kisu.units.mechanics.RadiantIntensity
+import org.kisu.units.mechanics.SpecificAngularMomentum
+import org.kisu.units.mechanics.SpecificEnergy
+import org.kisu.units.mechanics.SpecificVolume
+import org.kisu.units.mechanics.SpectralIrradiance
+import org.kisu.units.mechanics.SpectralPower
+import org.kisu.units.mechanics.SpectralRadiance
+import org.kisu.units.mechanics.Spectralntensity
+import org.kisu.units.mechanics.SurfaceTension
+import org.kisu.units.photometric.Efficacy
+import org.kisu.units.photometric.Luminance
+import org.kisu.units.photometric.LuminousEnergy
 import org.kisu.units.special.AbsorbedDose
 import org.kisu.units.special.Area
 import org.kisu.units.special.Capacitance
@@ -34,8 +99,18 @@ import org.kisu.units.special.Radioactivity
 import org.kisu.units.special.Resistance
 import org.kisu.units.special.SolidAngle
 import org.kisu.units.special.Volume
+import org.kisu.units.thermodynamics.HeatCapacity
+import org.kisu.units.thermodynamics.SpecificHeatCapacity
+import org.kisu.units.thermodynamics.TemperatureGradient
+import org.kisu.units.thermodynamics.ThermalConductivity
 import org.kisu.units.thermodynamics.ThermalExpansionCoefficient
+import org.kisu.units.thermodynamics.ThermalResistance
 import java.math.BigDecimal
+import org.kisu.units.kinematics.angular.Acceleration as AngularAcceleration
+import org.kisu.units.kinematics.angular.Crackle as AngularCrackle
+import org.kisu.units.kinematics.angular.Jerk as AngularJerk
+import org.kisu.units.kinematics.angular.Pop as AngularPop
+import org.kisu.units.kinematics.angular.Snap as AngularSnap
 
 /**
  * Represents a metric unit builder carrying a magnitude value.
@@ -51,6 +126,39 @@ sealed interface MetricUnitBuilder {
     /** The metric prefix associated with this builder (e.g., [Metric.KILO], [Metric.MILLI]). */
     val metric: Metric
 }
+
+/**
+ * Creates a [Magnetization] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val magnetization = 1.amperePerMetre // 1 A/m
+ * ```
+ */
+val MetricUnitBuilder.amperePerMetre: Magnetization
+    get() = Magnetization(magnitude, metric)
+
+/**
+ * Creates an [ElectricCurrentDensity] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val currentDensity = 1.micro.amperePerSquareMetre // 1 * 10^-6 A/m²
+ * ```
+ */
+val MetricUnitBuilder.amperePerSquareMetre: ElectricCurrentDensity
+    get() = ElectricCurrentDensity(magnitude, metric)
+
+/**
+ * Creates a [MagnetomotiveForce] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val mmf = 1.kilo.ampereRadian // 1000 A·rad
+ * ```
+ */
+val MetricUnitBuilder.ampereRadian: MagnetomotiveForce
+    get() = MagnetomotiveForce(magnitude, metric)
 
 /**
  * Creates a [Current] measure by applying the metric prefix scale to the magnitude.
@@ -83,6 +191,17 @@ val MetricUnitBuilder.becquerels: Radioactivity get() = Radioactivity(magnitude,
 val MetricUnitBuilder.bytes: org.kisu.units.special.Bytes get() = org.kisu.units.special.Bytes(magnitude, metric)
 
 /**
+ * Creates a [Luminance] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val luminance = 1.kilo.candelaPerSquareMetre // 1000 cd/m²
+ * ```
+ */
+val MetricUnitBuilder.candelaPerSquareMetre: Luminance
+    get() = Luminance(magnitude, metric)
+
+/**
  * Creates a [LuminousIntensity] measure by applying the metric prefix scale to the magnitude.
  *
  * Example usage:
@@ -103,6 +222,50 @@ val MetricUnitBuilder.candelas: LuminousIntensity get() = LuminousIntensity(magn
 val MetricUnitBuilder.celsius: CelsiusTemperature get() = CelsiusTemperature(magnitude, metric)
 
 /**
+ * Creates an [ElectricChargeDensity] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val chargeDensity = 1.micro.coulombPerCubicMetre // 1 * 10^-6 C/m³
+ * ```
+ */
+val MetricUnitBuilder.coulombPerCubicMetre: ElectricChargeDensity
+    get() = ElectricChargeDensity(magnitude, metric)
+
+/**
+ * Creates an [Exposure] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val exposure = 1.milli.coulombPerKilogram // 0.001 C/kg
+ * ```
+ */
+val MetricUnitBuilder.coulombPerKilogram: Exposure
+    get() = Exposure(magnitude, metric)
+
+/**
+ * Creates a [LinearChargeDensity] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val linearCharge = 1.micro.coulombPerMetre // 1 * 10^-6 C/m
+ * ```
+ */
+val MetricUnitBuilder.coulombPerMetre: LinearChargeDensity
+    get() = LinearChargeDensity(magnitude, metric)
+
+/**
+ * Creates an [ElectricDisplacementField] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val displacementField = 1.kilo.coulombPerSquareMetre // 1000 C/m²
+ * ```
+ */
+val MetricUnitBuilder.coulombPerSquareMetre: ElectricDisplacementField
+    get() = ElectricDisplacementField(magnitude, metric)
+
+/**
  * Creates an [ElectricCharge] measure by applying the metric prefix scale to the magnitude.
  *
  * Example usage:
@@ -113,6 +276,50 @@ val MetricUnitBuilder.celsius: CelsiusTemperature get() = CelsiusTemperature(mag
 val MetricUnitBuilder.coulombs: ElectricCharge get() = ElectricCharge(magnitude, metric)
 
 /**
+ * Creates a [SpecificVolume] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val specificVolume = 1.kilo.cubicMetrePerKilogram // 1000 m³/kg
+ * ```
+ */
+val MetricUnitBuilder.cubicMetrePerKilogram: SpecificVolume
+    get() = SpecificVolume(magnitude, metric)
+
+/**
+ * Creates a [MolarVolume] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val molarVolume = 1.milli.cubicMetrePerMole // 0.001 m³/mol
+ * ```
+ */
+val MetricUnitBuilder.cubicMetrePerMole: MolarVolume
+    get() = MolarVolume(magnitude, metric)
+
+/**
+ * Creates a [CatalyticEfficiency] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val catalyticEfficiency = 1.micro.cubicMetrePerMoleSecond // 1 * 10^-6 m³/(mol·s)
+ * ```
+ */
+val MetricUnitBuilder.cubicMetrePerMoleSecond: CatalyticEfficiency
+    get() = CatalyticEfficiency(magnitude, metric)
+
+/**
+ * Creates a [VolumetricFlow] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val volumetricFlow = 1.litre.cubicMetrePerSecond // 0.001 m³/s
+ * ```
+ */
+val MetricUnitBuilder.cubicMetrePerSecond: VolumetricFlow
+    get() = VolumetricFlow(magnitude, metric)
+
+/**
  * Creates a [Volume] measure by applying the metric prefix scale to the magnitude.
  *
  * Example usage:
@@ -121,6 +328,17 @@ val MetricUnitBuilder.coulombs: ElectricCharge get() = ElectricCharge(magnitude,
  * ```
  */
 val MetricUnitBuilder.cubicMetres: Volume get() = Volume(magnitude, metric)
+
+/**
+ * Creates a [Permittivity] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val permittivity = 1.micro.faradPerMetre // 1 * 10^-6 F/m
+ * ```
+ */
+val MetricUnitBuilder.faradPerMetre: Permittivity
+    get() = Permittivity(magnitude, metric)
 
 /**
  * Creates a [Capacitance] measure by applying the metric prefix scale to the magnitude.
@@ -145,6 +363,17 @@ val MetricUnitBuilder.farads: Capacitance get() = Capacitance(magnitude, metric)
 val MetricUnitBuilder.grams: Mass get() = Mass(magnitude, metric)
 
 /**
+ * Creates an [AbsorbedDoseRate] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val doseRate = 1.milli.grayPerSecond // 0.001 Gy/s
+ * ```
+ */
+val MetricUnitBuilder.grayPerSecond: AbsorbedDoseRate
+    get() = AbsorbedDoseRate(magnitude, metric)
+
+/**
  * Creates an [AbsorbedDose] measure by applying the metric prefix scale to the magnitude.
  *
  * Example usage:
@@ -153,16 +382,6 @@ val MetricUnitBuilder.grams: Mass get() = Mass(magnitude, metric)
  * ```
  */
 val MetricUnitBuilder.grays: AbsorbedDose get() = AbsorbedDose(magnitude, metric)
-
-/**
- * Creates an [Energy] measure by applying the metric prefix scale to the magnitude.
- *
- * Example usage:
- * ```
- * val energy = 5.mega.joules // 5 * 10^6 joules
- * ```
- */
-val MetricUnitBuilder.joules: Energy get() = Energy(magnitude, metric)
 
 /**
  * Creates an [Inductance] measure by applying the metric prefix scale to the magnitude.
@@ -175,6 +394,17 @@ val MetricUnitBuilder.joules: Energy get() = Energy(magnitude, metric)
 val MetricUnitBuilder.henries: Inductance get() = Inductance(magnitude, metric)
 
 /**
+ * Creates a [MagneticPermittivity] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val magneticPermittivity = 1.kilo.henryPerMetre // 1000 H/m
+ * ```
+ */
+val MetricUnitBuilder.henryPerMetre: MagneticPermittivity
+    get() = MagneticPermittivity(magnitude, metric)
+
+/**
  * Creates a [Frequency] measure by applying the metric prefix scale to the magnitude.
  *
  * Example usage:
@@ -183,6 +413,137 @@ val MetricUnitBuilder.henries: Inductance get() = Inductance(magnitude, metric)
  * ```
  */
 val MetricUnitBuilder.hertz: Frequency get() = Frequency(magnitude, metric)
+
+/**
+ * Creates a [FrequencyDrift] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val frequencyDrift = 1.milli.hertzPerSecond // 0.001 Hz/s
+ * ```
+ */
+val MetricUnitBuilder.hertzPerSecond: FrequencyDrift
+    get() = FrequencyDrift(magnitude, metric)
+
+/**
+ * Creates an [EnergyDensity] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val energyDensity = 1.kilo.joulePerCubicMetre // 1000 J/m³
+ * ```
+ */
+val MetricUnitBuilder.joulePerCubicMetre: EnergyDensity
+    get() = EnergyDensity(magnitude, metric)
+
+/**
+ * Creates a [HeatCapacity] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val heatCapacity = 1.kilo.joulePerKelvin // 1000 J/K
+ * ```
+ */
+val MetricUnitBuilder.joulePerKelvin: HeatCapacity
+    get() = HeatCapacity(magnitude, metric)
+
+/**
+ * Creates a [MolarHeatCapacity] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val molarHeatCapacity = 1.joulePerKelvinMole // 1 J/(K·mol)
+ * ```
+ */
+val MetricUnitBuilder.joulePerKelvinMole: MolarHeatCapacity
+    get() = MolarHeatCapacity(magnitude, metric)
+
+/**
+ * Creates a [SpecificEnergy] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val specificEnergy = 1.kilo.joulePerKilogram // 1000 J/kg
+ * ```
+ */
+val MetricUnitBuilder.joulePerKilogram: SpecificEnergy
+    get() = SpecificEnergy(magnitude, metric)
+
+/**
+ * Creates a [SpecificHeatCapacity] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val specificHeat = 1.kilo.joulePerKilogramKelvin // 1000 J/(kg·K)
+ * ```
+ */
+val MetricUnitBuilder.joulePerKilogramKelvin: SpecificHeatCapacity
+    get() = SpecificHeatCapacity(magnitude, metric)
+
+/**
+ * Creates a [MolarEnergy] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val molarEnergy = 1.kilo.joulePerMole // 1000 J/mol
+ * ```
+ */
+val MetricUnitBuilder.joulePerMole: MolarEnergy
+    get() = MolarEnergy(magnitude, metric)
+
+/**
+ * Creates a [RadiantExposure] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val radiantExposure = 1.milli.joulePerSquareMetre // 0.001 J/m²
+ * ```
+ */
+val MetricUnitBuilder.joulePerSquareMetre: RadiantExposure
+    get() = RadiantExposure(magnitude, metric)
+
+/**
+ * Creates an [EnergyFluxDensity] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val energyFlux = 1.kilo.joulePerSquareMetreSecond // 1000 J/(m²·s)
+ * ```
+ */
+val MetricUnitBuilder.joulePerSquareMetreSecond: EnergyFluxDensity
+    get() = EnergyFluxDensity(magnitude, metric)
+
+/**
+ * Creates a [MagneticDipoleMoment] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val dipoleMoment = 1.kilo.joulePerTesla // 1000 J/T
+ * ```
+ */
+val MetricUnitBuilder.joulePerTesla: MagneticDipoleMoment
+    get() = MagneticDipoleMoment(magnitude, metric)
+
+/**
+ * Creates an [Energy] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val energy = 5.mega.joules // 5 * 10^6 joules
+ * ```
+ */
+val MetricUnitBuilder.joules: Energy get() = Energy(magnitude, metric)
+
+/**
+ * Creates an [Action] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val action = 1.kilo.jouleSecond // 1000 J·s
+ * ```
+ */
+val MetricUnitBuilder.jouleSecond: Action
+    get() = Action(magnitude, metric)
 
 /**
  * Creates a [CatalyticActivity] measure by applying the metric prefix scale to the magnitude.
@@ -195,6 +556,28 @@ val MetricUnitBuilder.hertz: Frequency get() = Frequency(magnitude, metric)
 val MetricUnitBuilder.katals: CatalyticActivity get() = CatalyticActivity(magnitude, metric)
 
 /**
+ * Creates a [TemperatureGradient] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val tempGradient = 1.kelvinPerMetre // 1 K/m
+ * ```
+ */
+val MetricUnitBuilder.kelvinPerMetre: TemperatureGradient
+    get() = TemperatureGradient(magnitude, metric)
+
+/**
+ * Creates a [ThermalResistance] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val thermalResistance = 1.kelvinPerWatt // 1 K/W
+ * ```
+ */
+val MetricUnitBuilder.kelvinPerWatt: ThermalResistance
+    get() = ThermalResistance(magnitude, metric)
+
+/**
  * Creates a [Temperature] measure by applying the metric prefix scale to the magnitude.
  *
  * Example usage:
@@ -203,6 +586,105 @@ val MetricUnitBuilder.katals: CatalyticActivity get() = CatalyticActivity(magnit
  * ```
  */
 val MetricUnitBuilder.kelvins: Temperature get() = Temperature(magnitude, metric)
+
+/**
+ * Creates a [Yank] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val yank = 1.kilogramMetre // 1 kg·m/s³
+ * ```
+ */
+val MetricUnitBuilder.kilogramMetre: Yank
+    get() = Yank(magnitude, metric)
+
+/**
+ * Creates a [Yank] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val yank = 1.kilogramMetreSecondThird // 1 kg·m/s³
+ * ```
+ */
+val MetricUnitBuilder.kilogramMetreSecondThird: Yank
+    get() = Yank(magnitude, metric)
+
+/**
+ * Creates a [Density] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val density = 1.kilogramPerCubicMetre // 1 kg/m³
+ * ```
+ */
+val MetricUnitBuilder.kilogramPerCubicMetre: Density
+    get() = Density(magnitude, metric)
+
+/**
+ * Creates a [LinearMassDensity] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val linearMassDensity = 1.kilogramPerMetre // 1 kg/m
+ * ```
+ */
+val MetricUnitBuilder.kilogramPerMetre: LinearMassDensity
+    get() = LinearMassDensity(magnitude, metric)
+
+/**
+ * Creates a [MolarMass] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val molarMass = 1.kilogramPerMole // 1 kg/mol
+ * ```
+ */
+val MetricUnitBuilder.kilogramPerMole: MolarMass
+    get() = MolarMass(magnitude, metric)
+
+/**
+ * Creates a [MassFlowRate] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val massFlow = 1.kilogramPerSecond // 1 kg/s
+ * ```
+ */
+val MetricUnitBuilder.kilogramPerSecond: MassFlowRate
+    get() = MassFlowRate(magnitude, metric)
+
+/**
+ * Creates an [AreaDensity] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val areaDensity = 1.kilogramPerSquareMetre // 1 kg/m²
+ * ```
+ */
+val MetricUnitBuilder.kilogramPerSquareMetre: AreaDensity
+    get() = AreaDensity(magnitude, metric)
+
+/**
+ * Creates a [MomentOfIntertia] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val inertia = 1.kilogramSquareMetre // 1 kg·m²
+ * ```
+ */
+val MetricUnitBuilder.kilogramSquareMetre: MomentOfIntertia
+    get() = MomentOfIntertia(magnitude, metric)
+
+/**
+ * Creates an [Efficacy] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val efficacy = 1.lumenPerWatt // 1 lm/W
+ * ```
+ */
+val MetricUnitBuilder.lumenPerWatt: Efficacy
+    get() = Efficacy(magnitude, metric)
 
 /**
  * Creates a [LuminousFlux] measure by applying the metric prefix scale to the magnitude.
@@ -215,6 +697,17 @@ val MetricUnitBuilder.kelvins: Temperature get() = Temperature(magnitude, metric
 val MetricUnitBuilder.lumens: LuminousFlux get() = LuminousFlux(magnitude, metric)
 
 /**
+ * Creates a [LuminousEnergy] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val luminousEnergy = 1.lumenSecond // 1 lm·s
+ * ```
+ */
+val MetricUnitBuilder.lumenSecond: LuminousEnergy
+    get() = LuminousEnergy(magnitude, metric)
+
+/**
  * Creates an [Illuminance] measure by applying the metric prefix scale to the magnitude.
  *
  * Example usage:
@@ -223,6 +716,105 @@ val MetricUnitBuilder.lumens: LuminousFlux get() = LuminousFlux(magnitude, metri
  * ```
  */
 val MetricUnitBuilder.lux: Illuminance get() = Illuminance(magnitude, metric)
+
+/**
+ * Creates an [Exposure] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val exposure = 1.luxSecond // 1 lx·s
+ * ```
+ */
+val MetricUnitBuilder.luxSecond: Exposure
+    get() = Exposure(magnitude, metric)
+
+/**
+ * Creates a [FuelEfficiency] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val fuelEfficiency = 1.metrePerCubicMetre // 1 m/m³
+ * ```
+ */
+val MetricUnitBuilder.metrePerCubicMetre: FuelEfficiency
+    get() = FuelEfficiency(magnitude, metric)
+
+/**
+ * Creates a [MagneticSusceptibility] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val magneticSusceptibility = 1.metrePerHenry // 1 m/H
+ * ```
+ */
+val MetricUnitBuilder.metrePerHenry: MagneticSusceptibility
+    get() = MagneticSusceptibility(magnitude, metric)
+
+/**
+ * Creates a [Speed] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val speed = 1.metrePerSecond // 1 m/s
+ * ```
+ */
+val MetricUnitBuilder.metrePerSecond: Speed
+    get() = Speed(magnitude, metric)
+
+/**
+ * Creates a [Jerk] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val jerk = 1.metrePerSecondCubed // 1 m/s³
+ * ```
+ */
+val MetricUnitBuilder.metrePerSecondCubed: Jerk
+    get() = Jerk(magnitude, metric)
+
+/**
+ * Creates a [Crackle] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val crackle = 1.metrePerSecondFifth // 1 m/s⁵
+ * ```
+ */
+val MetricUnitBuilder.metrePerSecondFifth: Crackle
+    get() = Crackle(magnitude, metric)
+
+/**
+ * Creates a [Snap] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val snap = 1.metrePerSecondFourth // 1 m/s⁴
+ * ```
+ */
+val MetricUnitBuilder.metrePerSecondFourth: Snap
+    get() = Snap(magnitude, metric)
+
+/**
+ * Creates a [Pop] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val pop = 1.metrePerSecondSixth // 1 m/s⁶
+ * ```
+ */
+val MetricUnitBuilder.metrePerSecondSixth: Pop
+    get() = Pop(magnitude, metric)
+
+/**
+ * Creates an [Acceleration] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val acceleration = 1.metrePerSecondSquared // 1 m/s²
+ * ```
+ */
+val MetricUnitBuilder.metrePerSecondSquared: Acceleration
+    get() = Acceleration(magnitude, metric)
 
 /**
  * Creates a [Length] measure by applying the metric prefix scale to the magnitude.
@@ -235,6 +827,28 @@ val MetricUnitBuilder.lux: Illuminance get() = Illuminance(magnitude, metric)
 val MetricUnitBuilder.metres: Length get() = Length(magnitude, metric)
 
 /**
+ * Creates a [Molarity] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val molarity = 1.molePerCubicMetre // 1 mol/m³
+ * ```
+ */
+val MetricUnitBuilder.molePerCubicMetre: Molarity
+    get() = Molarity(magnitude, metric)
+
+/**
+ * Creates a [Molality] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val molality = 1.molPerKilogram // 1 mol/kg
+ * ```
+ */
+val MetricUnitBuilder.molPerKilogram: Molality
+    get() = Molality(magnitude, metric)
+
+/**
  * Creates an [Amount] measure by applying the metric prefix scale to the magnitude.
  *
  * Example usage:
@@ -245,6 +859,39 @@ val MetricUnitBuilder.metres: Length get() = Length(magnitude, metric)
 val MetricUnitBuilder.moles: Amount get() = Amount(magnitude, metric)
 
 /**
+ * Creates an [AngularMomentum] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val angularMomentum = 1.newtonMeterSecond // 1 N·m·s
+ * ```
+ */
+val MetricUnitBuilder.newtonMeterSecond: AngularMomentum
+    get() = AngularMomentum(magnitude, metric)
+
+/**
+ * Creates a [SpecificAngularMomentum] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val specificAngularMomentum = 1.newtonMetreSecondPerKilogram // 1 N·m·s/kg
+ * ```
+ */
+val MetricUnitBuilder.newtonMetreSecondPerKilogram: SpecificAngularMomentum
+    get() = SpecificAngularMomentum(magnitude, metric)
+
+/**
+ * Creates a [SurfaceTension] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val surfaceTension = 1.newtonPerMetre // 1 N/m
+ * ```
+ */
+val MetricUnitBuilder.newtonPerMetre: SurfaceTension
+    get() = SurfaceTension(magnitude, metric)
+
+/**
  * Creates a [Force] measure by applying the metric prefix scale to the magnitude.
  *
  * Example usage:
@@ -253,6 +900,28 @@ val MetricUnitBuilder.moles: Amount get() = Amount(magnitude, metric)
  * ```
  */
 val MetricUnitBuilder.newtons: Force get() = Force(magnitude, metric)
+
+/**
+ * Creates a [Momentum] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val momentum = 1.newtonSecond // 1 N·s
+ * ```
+ */
+val MetricUnitBuilder.newtonSecond: Momentum
+    get() = Momentum(magnitude, metric)
+
+/**
+ * Creates a [Resistivity] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val resistivity = 1.ohmMetre // 1 Ω·m
+ * ```
+ */
+val MetricUnitBuilder.ohmMetre: Resistivity
+    get() = Resistivity(magnitude, metric)
 
 /**
  * Creates a [Resistance] measure by applying the metric prefix scale to the magnitude.
@@ -273,6 +942,83 @@ val MetricUnitBuilder.ohms: Resistance get() = Resistance(magnitude, metric)
  * ```
  */
 val MetricUnitBuilder.pascals: Pressure get() = Pressure(magnitude, metric)
+
+/**
+ * Creates a [DynamicViscosity] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val viscosity = 1.pascalSecond // 1 Pa·s
+ * ```
+ */
+val MetricUnitBuilder.pascalSecond: DynamicViscosity
+    get() = DynamicViscosity(magnitude, metric)
+
+/**
+ * Creates a [Velocity] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val angularVelocity = 1.radianPerSecond // 1 rad/s
+ * ```
+ */
+val MetricUnitBuilder.radianPerSecond: Velocity
+    get() = Velocity(magnitude, metric)
+
+/**
+ * Creates an [AngularJerk] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val angularJerk = 1.radianPerSecondCubed // 1 rad/s³
+ * ```
+ */
+val MetricUnitBuilder.radianPerSecondCubed: AngularJerk
+    get() = AngularJerk(magnitude, metric)
+
+/**
+ * Creates an [AngularCrackle] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val angularCrackle = 1.radianPerSecondFifth // 1 rad/s⁵
+ * ```
+ */
+val MetricUnitBuilder.radianPerSecondFifth: AngularCrackle
+    get() = AngularCrackle(magnitude, metric)
+
+/**
+ * Creates an [AngularSnap] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val angularSnap = 1.radianPerSecondFourth // 1 rad/s⁴
+ * ```
+ */
+val MetricUnitBuilder.radianPerSecondFourth: AngularSnap
+    get() = AngularSnap(magnitude, metric)
+
+/**
+ * Creates an [AngularPop] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val angularPop = 1.radianPerSecondSixth // 1 rad/s⁶
+ * ```
+ */
+val MetricUnitBuilder.radianPerSecondSixth: AngularPop
+    get() = AngularPop(magnitude, metric)
+
+/**
+ * Creates an [AngularAcceleration] measure in radians per second squared.
+ *
+ * Example usage:
+ * ```
+ * val angularAcceleration = 1.radianPerSecondSquared
+ * ```
+ */
+val MetricUnitBuilder.radianPerSecondSquared: AngularAcceleration
+    get() = AngularAcceleration(magnitude, metric)
 
 /**
  * Creates a [PlaneAngle] measure by applying the metric prefix scale to the magnitude.
@@ -296,36 +1042,37 @@ val MetricUnitBuilder.reciprocalHenries: MagneticReluctance
     get() = MagneticReluctance(magnitude, metric)
 
 /**
- * Creates a [ThermalExpansionCoefficient] measure by applying the metric prefix scale to the magnitude.
+ * Creates a [ThermalExpansionCoefficient] measure in reciprocal kelvins.
  *
  * Example usage:
  * ```
- * val coefficient = 2.milli.reciprocalKelvins // 2 * 10^-3 K⁻¹
+ * val coefficient = 1.reciprocalKelvins
  * ```
  */
 val MetricUnitBuilder.reciprocalKelvins: ThermalExpansionCoefficient
     get() = ThermalExpansionCoefficient(magnitude, metric)
 
 /**
- * Creates a [Compressibility] measure by applying the metric prefix scale to the magnitude.
+ * Creates a [Compressibility] measure in reciprocal pascals.
  *
  * Example usage:
  * ```
- * val compressibility = 7.micro.reciprocalPascal // 7 * 10^-6 Pa⁻¹
+ * val compressibility = 1.reciprocalPascal
  * ```
  */
 val MetricUnitBuilder.reciprocalPascal: Compressibility
     get() = Compressibility(magnitude, metric)
 
 /**
- * Creates a [Time] measure by applying the metric prefix scale to the magnitude.
+ * Creates a [Time] measure in seconds.
  *
  * Example usage:
  * ```
- * val duration = 4.centi.seconds // 4 * 10^-2 seconds
+ * val time = 5.seconds
  * ```
  */
-val MetricUnitBuilder.seconds: Time get() = Time(magnitude, metric)
+val MetricUnitBuilder.seconds: Time
+    get() = Time(magnitude, metric)
 
 /**
  * Creates a [Conductance] measure by applying the metric prefix scale to the magnitude.
@@ -338,6 +1085,28 @@ val MetricUnitBuilder.seconds: Time get() = Time(magnitude, metric)
 val MetricUnitBuilder.siemens: Conductance get() = Conductance(magnitude, metric)
 
 /**
+ * Creates an [ElectricConductivity] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val conductivity = 1.siemensPerMetre // 1 S/m
+ * ```
+ */
+val MetricUnitBuilder.siemensPerMetre: ElectricConductivity
+    get() = ElectricConductivity(magnitude, metric)
+
+/**
+ * Creates a [MolarConductivity] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val molarConductivity = 1.siemesSquareMetrePerMole // 1 S·m²/mol
+ * ```
+ */
+val MetricUnitBuilder.siemensSquareMetrePerMole: MolarConductivity
+    get() = MolarConductivity(magnitude, metric)
+
+/**
  * Creates a [DoseEquivalent] measure by applying the metric prefix scale to the magnitude.
  *
  * Example usage:
@@ -346,6 +1115,28 @@ val MetricUnitBuilder.siemens: Conductance get() = Conductance(magnitude, metric
  * ```
  */
 val MetricUnitBuilder.sieverts: DoseEquivalent get() = DoseEquivalent(magnitude, metric)
+
+/**
+ * Creates a [KinematicViscosity] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val viscosity = 1.squareMetrePerSecond // 1 m²/s
+ * ```
+ */
+val MetricUnitBuilder.squareMetrePerSecond: KinematicViscosity
+    get() = KinematicViscosity(magnitude, metric)
+
+/**
+ * Creates an [ElectronMobility] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val mobility = 1.squareMetrePerVoltSecond // 1 m²/(V·s)
+ * ```
+ */
+val MetricUnitBuilder.squareMetrePerVoltSecond: ElectronMobility
+    get() = ElectronMobility(magnitude, metric)
 
 /**
  * Creates an [Area] measure by applying the metric prefix scale to the magnitude.
@@ -368,6 +1159,17 @@ val MetricUnitBuilder.squareMetres: Area get() = Area(magnitude, metric)
 val MetricUnitBuilder.steradians: SolidAngle get() = SolidAngle(magnitude, metric)
 
 /**
+ * Creates a [MagneticRigidity] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val rigidity = 1.teslaMetre // 1 T·m
+ * ```
+ */
+val MetricUnitBuilder.teslaMetre: MagneticRigidity
+    get() = MagneticRigidity(magnitude, metric)
+
+/**
  * Creates a [MagneticFluxDensity] measure by applying the metric prefix scale to the magnitude.
  *
  * Example usage:
@@ -376,6 +1178,17 @@ val MetricUnitBuilder.steradians: SolidAngle get() = SolidAngle(magnitude, metri
  * ```
  */
 val MetricUnitBuilder.teslas: MagneticFluxDensity get() = MagneticFluxDensity(magnitude, metric)
+
+/**
+ * Creates an [ElectricFieldStrength] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val field = 1.voltPerMetre // 1 V/m
+ * ```
+ */
+val MetricUnitBuilder.voltPerMetre: ElectricFieldStrength
+    get() = ElectricFieldStrength(magnitude, metric)
 
 /**
  * Creates an [ElectricPotential] measure by applying the metric prefix scale to the magnitude.
@@ -388,6 +1201,94 @@ val MetricUnitBuilder.teslas: MagneticFluxDensity get() = MagneticFluxDensity(ma
 val MetricUnitBuilder.volts: ElectricPotential get() = ElectricPotential(magnitude, metric)
 
 /**
+ * Creates a [SpectralIrradiance] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val irradiance = 1.wattPerCubicMetre // 1 W/m³
+ * ```
+ */
+val MetricUnitBuilder.wattPerCubicMetre: SpectralIrradiance
+    get() = SpectralIrradiance(magnitude, metric)
+
+/**
+ * Creates a [SpectralPower] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val spectralPower = 1.wattPerMetre // 1 W/m
+ * ```
+ */
+val MetricUnitBuilder.wattPerMetre: SpectralPower
+    get() = SpectralPower(magnitude, metric)
+
+/**
+ * Creates a [ThermalConductivity] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val thermalConductivity = 1.wattPerMetreKelvin // 1 W/(m·K)
+ * ```
+ */
+val MetricUnitBuilder.wattPerMetreKelvin: ThermalConductivity
+    get() = ThermalConductivity(magnitude, metric)
+
+/**
+ * Creates a [HeatFluxDensity] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val heatFlux = 1.wattPerSquareMetre // 1 W/m²
+ * ```
+ */
+val MetricUnitBuilder.wattPerSquareMetre: HeatFluxDensity
+    get() = HeatFluxDensity(magnitude, metric)
+
+/**
+ * Creates a [RadiantIntensity] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val radiantIntensity = 1.wattPerSteradian // 1 W/sr
+ * ```
+ */
+val MetricUnitBuilder.wattPerSteradian: RadiantIntensity
+    get() = RadiantIntensity(magnitude, metric)
+
+/**
+ * Creates a [SpectralRadiance] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val spectralRadiance = 1.wattPerSteradianCubicMetre // 1 W/(sr·m³)
+ * ```
+ */
+val MetricUnitBuilder.wattPerSteradianCubicMetre: SpectralRadiance
+    get() = SpectralRadiance(magnitude, metric)
+
+/**
+ * Creates a [Spectralntensity] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val spectralIntensity = 1.wattPerSteradianMetre // 1 W/(sr·m)
+ * ```
+ */
+val MetricUnitBuilder.wattPerSteradianMetre: Spectralntensity
+    get() = Spectralntensity(magnitude, metric)
+
+/**
+ * Creates a [Radiance] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val radiance = 1.wattPerSteradianSquareMetre // 1 W/(sr·m²)
+ * ```
+ */
+val MetricUnitBuilder.wattPerSteradianSquareMetre: Radiance
+    get() = Radiance(magnitude, metric)
+
+/**
  * Creates a [Power] measure by applying the metric prefix scale to the magnitude.
  *
  * Example usage:
@@ -396,6 +1297,28 @@ val MetricUnitBuilder.volts: ElectricPotential get() = ElectricPotential(magnitu
  * ```
  */
 val MetricUnitBuilder.watts: Power get() = Power(magnitude, metric)
+
+/**
+ * Creates a [MagneticMoment] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val magneticMoment = 1.weberMetre // 1 Wb·m
+ * ```
+ */
+val MetricUnitBuilder.weberMetre: MagneticMoment
+    get() = MagneticMoment(magnitude, metric)
+
+/**
+ * Creates a [MagneticVectorPotential] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val magneticVectorPotential = 1.weberPerMetre // 1 Wb/m
+ * ```
+ */
+val MetricUnitBuilder.weberPerMetre: MagneticVectorPotential
+    get() = MagneticVectorPotential(magnitude, metric)
 
 /**
  * Creates a [MagneticFlux] measure by applying the metric prefix scale to the magnitude.

--- a/lib/src/main/kotlin/org/kisu/units/builders/PrefixExtensions.kt
+++ b/lib/src/main/kotlin/org/kisu/units/builders/PrefixExtensions.kt
@@ -2,6 +2,7 @@ package org.kisu.units.builders
 
 import org.kisu.bigDecimal
 import org.kisu.prefixes.Binary
+import org.kisu.prefixes.Metric
 import org.kisu.units.base.Amount
 import org.kisu.units.base.Current
 import org.kisu.units.base.Information
@@ -85,7 +86,7 @@ val Number.coulombs get() = ElectricCharge(bigDecimal)
  * Creates a [Volume] from this [Number] representing a volume in cubic metres (m³),
  * the SI derived unit for volume.
  */
-val Number.cubicMeters get() = Volume(bigDecimal)
+val Number.cubicMetres get() = Volume(bigDecimal)
 
 /**
  * Creates a [Capacitance] from this [Number] representing a capacitance in farads (F),
@@ -97,7 +98,7 @@ val Number.farads get() = Capacitance(bigDecimal)
  * Creates a [Mass] from this [Number] representing a mass in grams (g).
  * Note: This assumes the base unit is the gram, not the kilogram.
  */
-val Number.grams get() = Mass(bigDecimal)
+val Number.grams get() = Mass(bigDecimal, Metric.BASE)
 
 /**
  * Creates an [AbsorbedDose] from this [Number] representing an absorbed dose in grays (Gy),
@@ -151,7 +152,7 @@ val Number.lux get() = Illuminance(bigDecimal)
  * Creates a [Length] from this [Number] representing a distance in meters (m),
  * the SI unit for length.
  */
-val Number.meters get() = Length(bigDecimal)
+val Number.metres get() = Length(bigDecimal)
 
 /**
  * Creates an [Amount] from this [Number] representing a number of moles (mol),
@@ -223,7 +224,7 @@ val Number.sieverts get() = DoseEquivalent(bigDecimal)
  * Creates an [Area] from this [Number] representing an area in square metres (m²),
  * the SI derived unit for area.
  */
-val Number.squareMeters get() = Area(bigDecimal)
+val Number.squareMetres get() = Area(bigDecimal)
 
 /**
  * Creates a [SolidAngle] from this [Number] representing a solid angle in steradians (sr),

--- a/lib/src/main/kotlin/org/kisu/units/builders/PrefixExtensions.kt
+++ b/lib/src/main/kotlin/org/kisu/units/builders/PrefixExtensions.kt
@@ -10,6 +10,8 @@ import org.kisu.units.base.LuminousIntensity
 import org.kisu.units.base.Mass
 import org.kisu.units.base.Temperature
 import org.kisu.units.base.Time
+import org.kisu.units.electromagnetic.MagneticReluctance
+import org.kisu.units.mechanics.Compressibility
 import org.kisu.units.special.AbsorbedDose
 import org.kisu.units.special.Area
 import org.kisu.units.special.Bytes
@@ -35,6 +37,7 @@ import org.kisu.units.special.Radioactivity
 import org.kisu.units.special.Resistance
 import org.kisu.units.special.SolidAngle
 import org.kisu.units.special.Volume
+import org.kisu.units.thermodynamics.ThermalExpansionCoefficient
 
 /**
  * Creates a [Current] from this [Number] representing an electric current in amperes (A),
@@ -185,6 +188,24 @@ val Number.radians get() = PlaneAngle(bigDecimal)
  * the SI unit for time.
  */
 val Number.seconds get() = Time(bigDecimal)
+
+/**
+ * Creates a [MagneticReluctance] from this [Number] representing a value in reciprocal henries (H⁻¹),
+ * the SI unit for magnetic reluctance.
+ */
+val Number.reciprocalHenries: MagneticReluctance get() = MagneticReluctance(bigDecimal)
+
+/**
+ * Creates a [ThermalExpansionCoefficient] from this [Number] representing a value in reciprocal kelvins (K⁻¹),
+ * the SI unit for thermal expansion coefficient.
+ */
+val Number.reciprocalKelvins: ThermalExpansionCoefficient get() = ThermalExpansionCoefficient(bigDecimal)
+
+/**
+ * Creates a [Compressibility] from this [Number] representing a value in reciprocal pascals (Pa⁻¹),
+ * the SI unit for compressibility.
+ */
+val Number.reciprocalPascal: Compressibility get() = Compressibility(bigDecimal)
 
 /**
  * Creates a [Conductance] from this [Number] representing an electrical conductance in siemens (S),

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/CatalyticEfficiency.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/CatalyticEfficiency.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.chemistry
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Mole
 import org.kisu.units.base.Second
@@ -51,4 +52,14 @@ typealias CubicMetrePerMoleSecond = Quotient<SquareMetre, Product<Mole, Second>>
 class CatalyticEfficiency(
     magnitude: BigDecimal,
     expression: CubicMetrePerMoleSecond
-) : Measure<CubicMetrePerMoleSecond, CatalyticEfficiency>(magnitude, expression, ::CatalyticEfficiency)
+) : Measure<CubicMetrePerMoleSecond, CatalyticEfficiency>(magnitude, expression, ::CatalyticEfficiency) {
+
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(
+            magnitude,
+            Quotient(
+                SquareMetre(prefix),
+                Product(Mole(), Second())
+            )
+        )
+}

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/Molality.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/Molality.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.chemistry
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Kilogram
 import org.kisu.units.base.Mole
@@ -44,4 +45,8 @@ typealias MolPerKilogram = Quotient<Mole, Kilogram>
 class Molality(
     magnitude: BigDecimal,
     expression: MolPerKilogram
-) : Measure<MolPerKilogram, Molality>(magnitude, expression, ::Molality)
+) : Measure<MolPerKilogram, Molality>(magnitude, expression, ::Molality) {
+
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Mole(prefix), Kilogram()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/MolarConductivity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/MolarConductivity.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.chemistry
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Mole
 import org.kisu.units.representation.Product
@@ -50,4 +51,14 @@ typealias SiemesSquareMetrePerMole = Quotient<Product<Siemens, SquareMetre>, Mol
 class MolarConductivity(
     magnitude: BigDecimal,
     expression: SiemesSquareMetrePerMole
-) : Measure<SiemesSquareMetrePerMole, MolarConductivity>(magnitude, expression, ::MolarConductivity)
+) : Measure<SiemesSquareMetrePerMole, MolarConductivity>(magnitude, expression, ::MolarConductivity) {
+
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(
+            magnitude,
+            Quotient(
+                Product(Siemens(prefix), SquareMetre()),
+                Mole()
+            )
+        )
+}

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/MolarEnergy.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/MolarEnergy.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.chemistry
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Mole
 import org.kisu.units.representation.Quotient
@@ -45,4 +46,8 @@ typealias JoulePerMole = Quotient<Joule, Mole>
 class MolarEnergy(
     magnitude: BigDecimal,
     expression: JoulePerMole
-) : Measure<JoulePerMole, MolarEnergy>(magnitude, expression, ::MolarEnergy)
+) : Measure<JoulePerMole, MolarEnergy>(magnitude, expression, ::MolarEnergy) {
+
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Joule(prefix), Mole()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/MolarHeatCapacity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/MolarHeatCapacity.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.chemistry
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Kelvin
 import org.kisu.units.base.Mole
@@ -46,4 +47,13 @@ typealias JoulePerKelvinMole = Quotient<Joule, Product<Kelvin, Mole>>
 class MolarHeatCapacity(
     magnitude: BigDecimal,
     expression: JoulePerKelvinMole
-) : Measure<JoulePerKelvinMole, MolarHeatCapacity>(magnitude, expression, ::MolarHeatCapacity)
+) : Measure<JoulePerKelvinMole, MolarHeatCapacity>(magnitude, expression, ::MolarHeatCapacity) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(
+            magnitude,
+            Quotient(
+                Joule(prefix),
+                Product(Kelvin(), Mole())
+            )
+        )
+}

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/MolarMass.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/MolarMass.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.chemistry
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Kilogram
 import org.kisu.units.base.Mole
@@ -42,4 +43,7 @@ typealias KilogramPerMole = Quotient<Kilogram, Mole>
 class MolarMass(
     magnitude: BigDecimal,
     expression: KilogramPerMole
-) : Measure<KilogramPerMole, MolarMass>(magnitude, expression, ::MolarMass)
+) : Measure<KilogramPerMole, MolarMass>(magnitude, expression, ::MolarMass) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Kilogram(prefix), Mole()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/MolarVolume.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/MolarVolume.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.chemistry
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Mole
 import org.kisu.units.representation.Quotient
@@ -43,4 +44,7 @@ typealias CubicMetrePerMole = Quotient<CubicMetre, Mole>
 class MolarVolume(
     magnitude: BigDecimal,
     expression: CubicMetrePerMole
-) : Measure<CubicMetrePerMole, MolarVolume>(magnitude, expression, ::MolarVolume)
+) : Measure<CubicMetrePerMole, MolarVolume>(magnitude, expression, ::MolarVolume) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(CubicMetre(prefix), Mole()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/Molarity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/Molarity.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.chemistry
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Mole
 import org.kisu.units.representation.Quotient
@@ -42,4 +43,7 @@ typealias MolePerCubicMetre = Quotient<Mole, CubicMetre>
 class Molarity(
     magnitude: BigDecimal,
     expression: MolePerCubicMetre
-) : Measure<MolePerCubicMetre, Molarity>(magnitude, expression, ::Molarity)
+) : Measure<MolePerCubicMetre, Molarity>(magnitude, expression, ::Molarity) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Mole(prefix), CubicMetre()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/ElectricChargeDensity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/ElectricChargeDensity.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.electromagnetic
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.representation.Quotient
 import org.kisu.units.special.Coulomb
@@ -42,4 +43,7 @@ typealias CoulombPerCubicMetre = Quotient<Coulomb, CubicMetre>
 class ElectricChargeDensity(
     magnitude: BigDecimal,
     expression: CoulombPerCubicMetre
-) : Measure<CoulombPerCubicMetre, ElectricChargeDensity>(magnitude, expression, ::ElectricChargeDensity)
+) : Measure<CoulombPerCubicMetre, ElectricChargeDensity>(magnitude, expression, ::ElectricChargeDensity) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Coulomb(prefix), CubicMetre()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/ElectricConductivity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/ElectricConductivity.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.electromagnetic
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Metre
 import org.kisu.units.representation.Quotient
@@ -44,4 +45,7 @@ typealias SiemensPerMetre = Quotient<Siemens, Metre>
 class ElectricConductivity(
     magnitude: BigDecimal,
     expression: SiemensPerMetre
-) : Measure<SiemensPerMetre, ElectricConductivity>(magnitude, expression, ::ElectricConductivity)
+) : Measure<SiemensPerMetre, ElectricConductivity>(magnitude, expression, ::ElectricConductivity) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Siemens(prefix), Metre()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/ElectricCurrentDensity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/ElectricCurrentDensity.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.electromagnetic
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Ampere
 import org.kisu.units.representation.Quotient
@@ -47,4 +48,7 @@ typealias AmperePerSquareMetre = Quotient<Ampere, SquareMetre>
 class ElectricCurrentDensity(
     magnitude: BigDecimal,
     expression: AmperePerSquareMetre
-) : Measure<AmperePerSquareMetre, ElectricCurrentDensity>(magnitude, expression, ::ElectricCurrentDensity)
+) : Measure<AmperePerSquareMetre, ElectricCurrentDensity>(magnitude, expression, ::ElectricCurrentDensity) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Ampere(prefix), SquareMetre()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/ElectricDisplacementField.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/ElectricDisplacementField.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.electromagnetic
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.representation.Quotient
 import org.kisu.units.special.Coulomb
@@ -46,4 +47,7 @@ typealias CoulombPerSquareMetre = Quotient<Coulomb, SquareMetre>
 class ElectricDisplacementField(
     magnitude: BigDecimal,
     expression: CoulombPerSquareMetre
-) : Measure<CoulombPerSquareMetre, ElectricDisplacementField>(magnitude, expression, ::ElectricDisplacementField)
+) : Measure<CoulombPerSquareMetre, ElectricDisplacementField>(magnitude, expression, ::ElectricDisplacementField) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Coulomb(prefix), SquareMetre()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/ElectricFieldStrength.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/ElectricFieldStrength.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.electromagnetic
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Metre
 import org.kisu.units.representation.Quotient
@@ -51,4 +52,7 @@ typealias VoltPerMetre = Quotient<Volt, Metre>
 class ElectricFieldStrength(
     magnitude: BigDecimal,
     expression: VoltPerMetre
-) : Measure<VoltPerMetre, ElectricFieldStrength>(magnitude, expression, ::ElectricFieldStrength)
+) : Measure<VoltPerMetre, ElectricFieldStrength>(magnitude, expression, ::ElectricFieldStrength) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Volt(prefix), Metre()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/ElectronMobility.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/ElectronMobility.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.electromagnetic
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Second
 import org.kisu.units.representation.Product
@@ -41,4 +42,13 @@ typealias SquareMetrePerVoltSecond = Quotient<SquareMetre, Product<Volt, Second>
 class ElectronMobility(
     magnitude: BigDecimal,
     expression: SquareMetrePerVoltSecond
-) : Measure<SquareMetrePerVoltSecond, ElectronMobility>(magnitude, expression, ::ElectronMobility)
+) : Measure<SquareMetrePerVoltSecond, ElectronMobility>(magnitude, expression, ::ElectronMobility) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(
+            magnitude,
+            Quotient(
+                SquareMetre(prefix),
+                Product(Volt(), Second())
+            )
+        )
+}

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/Exposure.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/Exposure.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.electromagnetic
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Kilogram
 import org.kisu.units.representation.Quotient
@@ -39,4 +40,7 @@ typealias CoulombPerKilogram = Quotient<Coulomb, Kilogram>
 class Exposure(
     magnitude: BigDecimal,
     expression: CoulombPerKilogram
-) : Measure<CoulombPerKilogram, Exposure>(magnitude, expression, ::Exposure)
+) : Measure<CoulombPerKilogram, Exposure>(magnitude, expression, ::Exposure) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Coulomb(prefix), Kilogram()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/LinearChargeDensity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/LinearChargeDensity.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.electromagnetic
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Metre
 import org.kisu.units.representation.Quotient
@@ -39,4 +40,7 @@ typealias CoulombPerMetre = Quotient<Coulomb, Metre>
 class LinearChargeDensity(
     magnitude: BigDecimal,
     expression: CoulombPerMetre
-) : Measure<CoulombPerMetre, LinearChargeDensity>(magnitude, expression, ::LinearChargeDensity)
+) : Measure<CoulombPerMetre, LinearChargeDensity>(magnitude, expression, ::LinearChargeDensity) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Coulomb(prefix), Metre()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/MagneticDipoleMoment.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/MagneticDipoleMoment.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.electromagnetic
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.representation.Quotient
 import org.kisu.units.special.Joule
@@ -38,4 +39,7 @@ typealias JoulePerTesla = Quotient<Joule, Tesla>
 class MagneticDipoleMoment(
     magnitude: BigDecimal,
     expression: JoulePerTesla
-) : Measure<JoulePerTesla, MagneticDipoleMoment>(magnitude, expression, ::MagneticDipoleMoment)
+) : Measure<JoulePerTesla, MagneticDipoleMoment>(magnitude, expression, ::MagneticDipoleMoment) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Joule(prefix), Tesla()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/MagneticMoment.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/MagneticMoment.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.electromagnetic
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Metre
 import org.kisu.units.representation.Product
@@ -43,4 +44,7 @@ typealias WeberMetre = Product<Weber, Metre>
 class MagneticMoment(
     magnitude: BigDecimal,
     expression: WeberMetre
-) : Measure<WeberMetre, MagneticMoment>(magnitude, expression, ::MagneticMoment)
+) : Measure<WeberMetre, MagneticMoment>(magnitude, expression, ::MagneticMoment) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Product(Weber(prefix), Metre()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/MagneticPermittivity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/MagneticPermittivity.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.electromagnetic
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Metre
 import org.kisu.units.representation.Quotient
@@ -45,4 +46,7 @@ typealias HenryPerMetre = Quotient<Henry, Metre>
 class MagneticPermittivity(
     magnitude: BigDecimal,
     expression: HenryPerMetre
-) : Measure<HenryPerMetre, MagneticPermittivity>(magnitude, expression, ::MagneticPermittivity)
+) : Measure<HenryPerMetre, MagneticPermittivity>(magnitude, expression, ::MagneticPermittivity) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Henry(prefix), Metre()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/MagneticReluctance.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/MagneticReluctance.kt
@@ -5,8 +5,6 @@ import org.kisu.units.Measure
 import org.kisu.units.representation.Scalar
 import org.kisu.units.representation.Unit
 import org.kisu.units.special.Henry
-import org.kisu.units.special.PlaneAngle
-import org.kisu.units.special.Radian
 import java.math.BigDecimal
 
 /**

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/MagneticReluctance.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/MagneticReluctance.kt
@@ -5,6 +5,8 @@ import org.kisu.units.Measure
 import org.kisu.units.representation.Scalar
 import org.kisu.units.representation.Unit
 import org.kisu.units.special.Henry
+import org.kisu.units.special.PlaneAngle
+import org.kisu.units.special.Radian
 import java.math.BigDecimal
 
 /**
@@ -34,7 +36,11 @@ import java.math.BigDecimal
 class MagneticReluctance(
     magnitude: BigDecimal,
     expression: ReciprocalHenry
-) : Measure<ReciprocalHenry, MagneticReluctance>(magnitude, expression, ::MagneticReluctance)
+) : Measure<ReciprocalHenry, MagneticReluctance>(magnitude, expression, ::MagneticReluctance) {
+
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, ReciprocalHenry(prefix))
+}
 
 /**
  * Represents the **reciprocal of inductance** (1/H), a scalar quantity used

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/MagneticRigidity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/MagneticRigidity.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.electromagnetic
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Metre
 import org.kisu.units.representation.Product
@@ -46,4 +47,7 @@ typealias TeslaMetre = Product<Tesla, Metre>
 class MagneticRigidity(
     magnitude: BigDecimal,
     expression: TeslaMetre
-) : Measure<TeslaMetre, MagneticRigidity>(magnitude, expression, ::MagneticRigidity)
+) : Measure<TeslaMetre, MagneticRigidity>(magnitude, expression, ::MagneticRigidity) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Product(Tesla(prefix), Metre()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/MagneticSusceptibility.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/MagneticSusceptibility.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.electromagnetic
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Metre
 import org.kisu.units.representation.Quotient
@@ -43,4 +44,7 @@ typealias MetrePerHenry = Quotient<Metre, Henry>
 class MagneticSusceptibility(
     magnitude: BigDecimal,
     expression: MetrePerHenry
-) : Measure<MetrePerHenry, MagneticSusceptibility>(magnitude, expression, ::MagneticSusceptibility)
+) : Measure<MetrePerHenry, MagneticSusceptibility>(magnitude, expression, ::MagneticSusceptibility) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Metre(prefix), Henry()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/MagneticVectorPotential.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/MagneticVectorPotential.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.electromagnetic
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Metre
 import org.kisu.units.representation.Quotient
@@ -46,4 +47,7 @@ typealias WeberPerMetre = Quotient<Weber, Metre>
 class MagneticVectorPotential(
     magnitude: BigDecimal,
     expression: WeberPerMetre
-) : Measure<WeberPerMetre, MagneticVectorPotential>(magnitude, expression, ::MagneticVectorPotential)
+) : Measure<WeberPerMetre, MagneticVectorPotential>(magnitude, expression, ::MagneticVectorPotential) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Weber(prefix), Metre()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/Magnetization.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/Magnetization.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.electromagnetic
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Ampere
 import org.kisu.units.base.Metre
@@ -45,4 +46,7 @@ typealias AmperePerMetre = Quotient<Ampere, Metre>
 class Magnetization(
     magnitude: BigDecimal,
     expression: AmperePerMetre
-) : Measure<AmperePerMetre, Magnetization>(magnitude, expression, ::Magnetization)
+) : Measure<AmperePerMetre, Magnetization>(magnitude, expression, ::Magnetization) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Ampere(prefix), Metre()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/MagnetomotiveForce.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/MagnetomotiveForce.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.electromagnetic
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Ampere
 import org.kisu.units.representation.Product
@@ -48,4 +49,7 @@ typealias AmpereRadian = Product<Ampere, Radian>
 class MagnetomotiveForce(
     magnitude: BigDecimal,
     expression: AmpereRadian
-) : Measure<AmpereRadian, MagnetomotiveForce>(magnitude, expression, ::MagnetomotiveForce)
+) : Measure<AmpereRadian, MagnetomotiveForce>(magnitude, expression, ::MagnetomotiveForce) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Product(Ampere(prefix), Radian()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/Permittivity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/Permittivity.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.electromagnetic
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Metre
 import org.kisu.units.representation.Quotient
@@ -44,4 +45,7 @@ typealias FaradPerMetre = Quotient<Farad, Metre>
 class Permittivity(
     magnitude: BigDecimal,
     expression: FaradPerMetre
-) : Measure<FaradPerMetre, Permittivity>(magnitude, expression, ::Permittivity)
+) : Measure<FaradPerMetre, Permittivity>(magnitude, expression, ::Permittivity) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Farad(prefix), Metre()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/Resistivity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/Resistivity.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.electromagnetic
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Metre
 import org.kisu.units.representation.Product
@@ -48,4 +49,7 @@ typealias OhmMetre = Product<Ohm, Metre>
 class Resistivity(
     magnitude: BigDecimal,
     expression: OhmMetre
-) : Measure<OhmMetre, Resistivity>(magnitude, expression, ::Resistivity)
+) : Measure<OhmMetre, Resistivity>(magnitude, expression, ::Resistivity) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Product(Ohm(prefix), Metre()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/FrequencyDrift.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/FrequencyDrift.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.kinematics
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Second
 import org.kisu.units.representation.Quotient
@@ -28,4 +29,7 @@ typealias HertzPerSecond = Quotient<Hertz, Second>
 class FrequencyDrift internal constructor(
     magnitude: BigDecimal,
     expression: HertzPerSecond
-) : Measure<HertzPerSecond, FrequencyDrift>(magnitude, expression, ::FrequencyDrift)
+) : Measure<HertzPerSecond, FrequencyDrift>(magnitude, expression, ::FrequencyDrift) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Hertz(prefix), Second()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/VolumetricFlow.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/VolumetricFlow.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.kinematics
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Second
 import org.kisu.units.representation.Quotient
@@ -28,4 +29,7 @@ typealias CubicMetrePerSecond = Quotient<CubicMetre, Second>
 class VolumetricFlow internal constructor(
     magnitude: BigDecimal,
     expression: CubicMetrePerSecond
-) : Measure<CubicMetrePerSecond, VolumetricFlow>(magnitude, expression, ::VolumetricFlow)
+) : Measure<CubicMetrePerSecond, VolumetricFlow>(magnitude, expression, ::VolumetricFlow) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(CubicMetre(prefix), Second()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/Yank.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/Yank.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.kinematics
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Kilogram
 import org.kisu.units.base.Metre
@@ -32,4 +33,13 @@ typealias KilogramMetreSecondThird = Quotient<KilogramMetre, SecondCubed>
 class Yank internal constructor(
     magnitude: BigDecimal,
     expression: KilogramMetreSecondThird
-) : Measure<KilogramMetreSecondThird, Yank>(magnitude, expression, ::Yank)
+) : Measure<KilogramMetreSecondThird, Yank>(magnitude, expression, ::Yank) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(
+            magnitude,
+            Quotient(
+                Product(Kilogram(prefix), Metre()),
+                SecondCubed()
+            )
+        )
+}

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Acceleration.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Acceleration.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.kinematics.angular
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.SecondSquared
 import org.kisu.units.representation.Quotient
@@ -28,4 +29,7 @@ typealias RadianPerSecondSquared = Quotient<Radian, SecondSquared>
 class Acceleration(
     magnitude: BigDecimal,
     expression: RadianPerSecondSquared
-) : Measure<RadianPerSecondSquared, Acceleration>(magnitude, expression, ::Acceleration)
+) : Measure<RadianPerSecondSquared, Acceleration>(magnitude, expression, ::Acceleration) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Radian(prefix), SecondSquared()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Crackle.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Crackle.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.kinematics.angular
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.SecondQuintic
 import org.kisu.units.representation.Quotient
@@ -29,4 +30,7 @@ typealias RadianPerSecondFifth = Quotient<Radian, SecondQuintic>
 class Crackle internal constructor(
     magnitude: BigDecimal,
     expression: RadianPerSecondFifth
-) : Measure<RadianPerSecondFifth, Crackle>(magnitude, expression, ::Crackle)
+) : Measure<RadianPerSecondFifth, Crackle>(magnitude, expression, ::Crackle) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Radian(prefix), SecondQuintic()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Jerk.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Jerk.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.kinematics.angular
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.SecondCubed
 import org.kisu.units.representation.Quotient
@@ -28,4 +29,7 @@ typealias RadianPerSecondCubed = Quotient<Radian, SecondCubed>
 class Jerk(
     magnitude: BigDecimal,
     expression: RadianPerSecondCubed
-) : Measure<RadianPerSecondCubed, Jerk>(magnitude, expression, ::Jerk)
+) : Measure<RadianPerSecondCubed, Jerk>(magnitude, expression, ::Jerk) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Radian(prefix), SecondCubed()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Pop.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Pop.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.kinematics.angular
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.SecondSextic
 import org.kisu.units.representation.Quotient
@@ -28,4 +29,7 @@ typealias RadianPerSecondSixth = Quotient<Radian, SecondSextic>
 class Pop internal constructor(
     magnitude: BigDecimal,
     expression: RadianPerSecondSixth
-) : Measure<RadianPerSecondSixth, Pop>(magnitude, expression, ::Pop)
+) : Measure<RadianPerSecondSixth, Pop>(magnitude, expression, ::Pop) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Radian(prefix), SecondSextic()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Snap.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Snap.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.kinematics.angular
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.SecondQuartic
 import org.kisu.units.representation.Quotient
@@ -28,4 +29,7 @@ typealias RadianPerSecondFourth = Quotient<Radian, SecondQuartic>
 class Snap(
     magnitude: BigDecimal,
     expression: RadianPerSecondFourth
-) : Measure<RadianPerSecondFourth, Snap>(magnitude, expression, ::Snap)
+) : Measure<RadianPerSecondFourth, Snap>(magnitude, expression, ::Snap) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Radian(prefix), SecondQuartic()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Velocity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Velocity.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.kinematics.angular
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Second
 import org.kisu.units.representation.Quotient
@@ -28,4 +29,7 @@ typealias RadianPerSecond = Quotient<Radian, Second>
 class Velocity(
     magnitude: BigDecimal,
     expression: RadianPerSecond
-) : Measure<RadianPerSecond, Velocity>(magnitude, expression, ::Velocity)
+) : Measure<RadianPerSecond, Velocity>(magnitude, expression, ::Velocity) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Radian(prefix), Second()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Acceleration.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Acceleration.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.kinematics.linear
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Metre
 import org.kisu.units.base.SecondSquared
@@ -28,4 +29,7 @@ typealias MetrePerSecondSquared = Quotient<Metre, SecondSquared>
 class Acceleration(
     magnitude: BigDecimal,
     expression: MetrePerSecondSquared
-) : Measure<MetrePerSecondSquared, Acceleration>(magnitude, expression, ::Acceleration)
+) : Measure<MetrePerSecondSquared, Acceleration>(magnitude, expression, ::Acceleration) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Metre(prefix), SecondSquared()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Crackle.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Crackle.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.kinematics.linear
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Metre
 import org.kisu.units.base.SecondQuintic
@@ -28,4 +29,7 @@ typealias MetrePerSecondFifth = Quotient<Metre, SecondQuintic>
 class Crackle internal constructor(
     magnitude: BigDecimal,
     expression: MetrePerSecondFifth
-) : Measure<MetrePerSecondFifth, Crackle>(magnitude, expression, ::Crackle)
+) : Measure<MetrePerSecondFifth, Crackle>(magnitude, expression, ::Crackle) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Metre(prefix), SecondQuintic()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Jerk.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Jerk.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.kinematics.linear
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Metre
 import org.kisu.units.base.SecondCubed
@@ -28,4 +29,7 @@ typealias MetrePerSecondCubed = Quotient<Metre, SecondCubed>
 class Jerk(
     magnitude: BigDecimal,
     expression: MetrePerSecondCubed
-) : Measure<MetrePerSecondCubed, Jerk>(magnitude, expression, ::Jerk)
+) : Measure<MetrePerSecondCubed, Jerk>(magnitude, expression, ::Jerk) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Metre(prefix), SecondCubed()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Pop.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Pop.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.kinematics.linear
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Metre
 import org.kisu.units.base.SecondSextic
@@ -28,4 +29,7 @@ typealias MetrePerSecondSixth = Quotient<Metre, SecondSextic>
 class Pop internal constructor(
     magnitude: BigDecimal,
     expression: MetrePerSecondSixth
-) : Measure<MetrePerSecondSixth, Pop>(magnitude, expression, ::Pop)
+) : Measure<MetrePerSecondSixth, Pop>(magnitude, expression, ::Pop) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Metre(prefix), SecondSextic()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Snap.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Snap.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.kinematics.linear
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Metre
 import org.kisu.units.base.SecondQuartic
@@ -28,4 +29,7 @@ typealias MetrePerSecondFourth = Quotient<Metre, SecondQuartic>
 class Snap(
     magnitude: BigDecimal,
     expression: MetrePerSecondFourth
-) : Measure<MetrePerSecondFourth, Snap>(magnitude, expression, ::Snap)
+) : Measure<MetrePerSecondFourth, Snap>(magnitude, expression, ::Snap) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Metre(prefix), SecondQuartic()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Speed.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Speed.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.kinematics.linear
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Metre
 import org.kisu.units.base.Second
@@ -24,4 +25,7 @@ typealias MetrePerSecond = Quotient<Metre, Second>
 class Speed(
     magnitude: BigDecimal,
     expression: MetrePerSecond
-) : Measure<MetrePerSecond, Speed>(magnitude, expression, ::Speed)
+) : Measure<MetrePerSecond, Speed>(magnitude, expression, ::Speed) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Metre(prefix), Second()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/AbsorbedDoseRate.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/AbsorbedDoseRate.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.mechanics
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Second
 import org.kisu.units.representation.Quotient
@@ -47,4 +48,7 @@ typealias GrayPerSecond = Quotient<Gray, Second>
 class AbsorbedDoseRate(
     magnitude: BigDecimal,
     expression: GrayPerSecond
-) : Measure<GrayPerSecond, AbsorbedDoseRate>(magnitude, expression, ::AbsorbedDoseRate)
+) : Measure<GrayPerSecond, AbsorbedDoseRate>(magnitude, expression, ::AbsorbedDoseRate) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Gray(prefix), Second()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/Action.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/Action.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.mechanics
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Second
 import org.kisu.units.representation.Product
@@ -38,4 +39,7 @@ typealias JouleSecond = Product<Joule, Second>
 class Action(
     magnitude: BigDecimal,
     expression: JouleSecond
-) : Measure<JouleSecond, Action>(magnitude, expression, ::Action)
+) : Measure<JouleSecond, Action>(magnitude, expression, ::Action) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Product(Joule(prefix), Second()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/AngularMomentum.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/AngularMomentum.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.mechanics
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Metre
 import org.kisu.units.base.Second
@@ -39,4 +40,7 @@ typealias NewtonMeterSecond = Product<Newton, Product<Metre, Second>>
 class AngularMomentum(
     magnitude: BigDecimal,
     expression: NewtonMeterSecond
-) : Measure<NewtonMeterSecond, AngularMomentum>(magnitude, expression, ::AngularMomentum)
+) : Measure<NewtonMeterSecond, AngularMomentum>(magnitude, expression, ::AngularMomentum) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Product(Newton(prefix), Product(Metre(), Second())))
+}

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/AreaDensity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/AreaDensity.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.mechanics
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Kilogram
 import org.kisu.units.representation.Quotient
@@ -37,4 +38,7 @@ typealias KilogramPerSquareMetre = Quotient<Kilogram, SquareMetre>
 class AreaDensity(
     magnitude: BigDecimal,
     expression: KilogramPerSquareMetre
-) : Measure<KilogramPerSquareMetre, AreaDensity>(magnitude, expression, ::AreaDensity)
+) : Measure<KilogramPerSquareMetre, AreaDensity>(magnitude, expression, ::AreaDensity) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Kilogram(prefix), SquareMetre()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/Compressibility.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/Compressibility.kt
@@ -2,8 +2,6 @@ package org.kisu.units.mechanics
 
 import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
-import org.kisu.units.electromagnetic.MagneticReluctance
-import org.kisu.units.electromagnetic.ReciprocalHenry
 import org.kisu.units.representation.Scalar
 import org.kisu.units.representation.Unit
 import org.kisu.units.special.Pascal

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/Compressibility.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/Compressibility.kt
@@ -2,6 +2,8 @@ package org.kisu.units.mechanics
 
 import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
+import org.kisu.units.electromagnetic.MagneticReluctance
+import org.kisu.units.electromagnetic.ReciprocalHenry
 import org.kisu.units.representation.Scalar
 import org.kisu.units.representation.Unit
 import org.kisu.units.special.Pascal
@@ -26,7 +28,11 @@ import java.math.BigDecimal
 class Compressibility(
     magnitude: BigDecimal,
     expression: ReciprocalPascal
-) : Measure<ReciprocalPascal, Compressibility>(magnitude, expression, ::Compressibility)
+) : Measure<ReciprocalPascal, Compressibility>(magnitude, expression, ::Compressibility) {
+
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, ReciprocalPascal(prefix))
+}
 
 /**
  * Unit of [Compressibility].

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/Density.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/Density.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.mechanics
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Kilogram
 import org.kisu.units.representation.Quotient
@@ -37,4 +38,7 @@ typealias KilogramPerCubicMetre = Quotient<Kilogram, CubicMetre>
 class Density(
     magnitude: BigDecimal,
     expression: KilogramPerCubicMetre
-) : Measure<KilogramPerCubicMetre, Density>(magnitude, expression, ::Density)
+) : Measure<KilogramPerCubicMetre, Density>(magnitude, expression, ::Density) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Kilogram(prefix), CubicMetre()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/DynamicViscosity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/DynamicViscosity.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.mechanics
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Second
 import org.kisu.units.representation.Product
@@ -38,4 +39,7 @@ typealias PascalSecond = Product<Pascal, Second>
 class DynamicViscosity(
     magnitude: BigDecimal,
     expression: PascalSecond
-) : Measure<PascalSecond, DynamicViscosity>(magnitude, expression, ::DynamicViscosity)
+) : Measure<PascalSecond, DynamicViscosity>(magnitude, expression, ::DynamicViscosity) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Product(Pascal(prefix), Second()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/EnergyDensity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/EnergyDensity.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.mechanics
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.representation.Quotient
 import org.kisu.units.special.CubicMetre
@@ -37,4 +38,7 @@ typealias JoulePerCubicMetre = Quotient<Joule, CubicMetre>
 class EnergyDensity(
     magnitude: BigDecimal,
     expression: JoulePerCubicMetre
-) : Measure<JoulePerCubicMetre, EnergyDensity>(magnitude, expression, ::EnergyDensity)
+) : Measure<JoulePerCubicMetre, EnergyDensity>(magnitude, expression, ::EnergyDensity) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Joule(prefix), CubicMetre()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/EnergyFluxDensity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/EnergyFluxDensity.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.mechanics
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Second
 import org.kisu.units.representation.Product
@@ -39,4 +40,13 @@ typealias JoulePerSquareMetreSecond = Quotient<Joule, Product<SquareMetre, Secon
 class EnergyFluxDensity(
     magnitude: BigDecimal,
     expression: JoulePerSquareMetreSecond
-) : Measure<JoulePerSquareMetreSecond, EnergyFluxDensity>(magnitude, expression, ::EnergyFluxDensity)
+) : Measure<JoulePerSquareMetreSecond, EnergyFluxDensity>(magnitude, expression, ::EnergyFluxDensity) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(
+            magnitude,
+            Quotient(
+                Joule(prefix),
+                Product(SquareMetre(), Second())
+            )
+        )
+}

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/FuelEfficiency.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/FuelEfficiency.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.mechanics
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Metre
 import org.kisu.units.representation.Quotient
@@ -38,4 +39,7 @@ typealias MetrePerCubicMetre = Quotient<Metre, CubicMetre>
 class FuelEfficiency(
     magnitude: BigDecimal,
     expression: MetrePerCubicMetre
-) : Measure<MetrePerCubicMetre, FuelEfficiency>(magnitude, expression, ::FuelEfficiency)
+) : Measure<MetrePerCubicMetre, FuelEfficiency>(magnitude, expression, ::FuelEfficiency) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Metre(prefix), CubicMetre()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/HeatFluxDensity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/HeatFluxDensity.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.mechanics
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.representation.Quotient
 import org.kisu.units.special.SquareMetre
@@ -37,4 +38,7 @@ typealias WattPerSquareMetre = Quotient<Watt, SquareMetre>
 class HeatFluxDensity(
     magnitude: BigDecimal,
     expression: WattPerSquareMetre
-) : Measure<WattPerSquareMetre, HeatFluxDensity>(magnitude, expression, ::HeatFluxDensity)
+) : Measure<WattPerSquareMetre, HeatFluxDensity>(magnitude, expression, ::HeatFluxDensity) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Watt(prefix), SquareMetre()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/KinematicViscosity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/KinematicViscosity.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.mechanics
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Second
 import org.kisu.units.representation.Quotient
@@ -38,4 +39,7 @@ typealias SquareMetrePerSecond = Quotient<SquareMetre, Second>
 class KinematicViscosity(
     magnitude: BigDecimal,
     expression: SquareMetrePerSecond
-) : Measure<SquareMetrePerSecond, KinematicViscosity>(magnitude, expression, ::KinematicViscosity)
+) : Measure<SquareMetrePerSecond, KinematicViscosity>(magnitude, expression, ::KinematicViscosity) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(SquareMetre(prefix), Second()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/LinearMassDensity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/LinearMassDensity.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.mechanics
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Kilogram
 import org.kisu.units.base.Metre
@@ -37,4 +38,7 @@ typealias KilogramPerMetre = Quotient<Kilogram, Metre>
 class LinearMassDensity(
     magnitude: BigDecimal,
     expression: KilogramPerMetre
-) : Measure<KilogramPerMetre, LinearMassDensity>(magnitude, expression, ::LinearMassDensity)
+) : Measure<KilogramPerMetre, LinearMassDensity>(magnitude, expression, ::LinearMassDensity) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Kilogram(prefix), Metre()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/MassFlowRate.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/MassFlowRate.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.mechanics
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Kilogram
 import org.kisu.units.base.Second
@@ -37,4 +38,7 @@ typealias KilogramPerSecond = Quotient<Kilogram, Second>
 class MassFlowRate(
     magnitude: BigDecimal,
     expression: KilogramPerSecond
-) : Measure<KilogramPerSecond, MassFlowRate>(magnitude, expression, ::MassFlowRate)
+) : Measure<KilogramPerSecond, MassFlowRate>(magnitude, expression, ::MassFlowRate) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Kilogram(prefix), Second()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/MomentOfIntertia.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/MomentOfIntertia.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.mechanics
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Kilogram
 import org.kisu.units.representation.Product
@@ -38,4 +39,7 @@ typealias KilogramSquareMetre = Product<Kilogram, SquareMetre>
 class MomentOfIntertia(
     magnitude: BigDecimal,
     expression: KilogramSquareMetre
-) : Measure<KilogramSquareMetre, MomentOfIntertia>(magnitude, expression, ::MomentOfIntertia)
+) : Measure<KilogramSquareMetre, MomentOfIntertia>(magnitude, expression, ::MomentOfIntertia) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Product(Kilogram(prefix), SquareMetre()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/Momentum.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/Momentum.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.mechanics
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Second
 import org.kisu.units.representation.Product
@@ -38,4 +39,7 @@ typealias NewtonSecond = Product<Newton, Second>
 class Momentum(
     magnitude: BigDecimal,
     expression: NewtonSecond
-) : Measure<NewtonSecond, Momentum>(magnitude, expression, ::Momentum)
+) : Measure<NewtonSecond, Momentum>(magnitude, expression, ::Momentum) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Product(Newton(prefix), Second()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/Radiance.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/Radiance.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.mechanics
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.representation.Product
 import org.kisu.units.representation.Quotient
@@ -40,4 +41,7 @@ typealias WattPerSteradianSquareMetre = Quotient<Watt, Product<Steradian, Square
 class Radiance(
     magnitude: BigDecimal,
     expression: WattPerSteradianSquareMetre
-) : Measure<WattPerSteradianSquareMetre, Radiance>(magnitude, expression, ::Radiance)
+) : Measure<WattPerSteradianSquareMetre, Radiance>(magnitude, expression, ::Radiance) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Watt(prefix), Product(Steradian(), SquareMetre())))
+}

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/RadiantExposure.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/RadiantExposure.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.mechanics
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.representation.Quotient
 import org.kisu.units.special.Joule
@@ -38,4 +39,7 @@ typealias JoulePerSquareMetre = Quotient<Joule, SquareMetre>
 class RadiantExposure(
     magnitude: BigDecimal,
     expression: JoulePerSquareMetre
-) : Measure<JoulePerSquareMetre, RadiantExposure>(magnitude, expression, ::RadiantExposure)
+) : Measure<JoulePerSquareMetre, RadiantExposure>(magnitude, expression, ::RadiantExposure) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Joule(prefix), SquareMetre()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/RadiantIntensity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/RadiantIntensity.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.mechanics
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.representation.Quotient
 import org.kisu.units.special.Steradian
@@ -37,4 +38,7 @@ typealias WattPerSteradian = Quotient<Watt, Steradian>
 class RadiantIntensity(
     magnitude: BigDecimal,
     expression: WattPerSteradian
-) : Measure<WattPerSteradian, RadiantIntensity>(magnitude, expression, ::RadiantIntensity)
+) : Measure<WattPerSteradian, RadiantIntensity>(magnitude, expression, ::RadiantIntensity) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Watt(prefix), Steradian()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/SpecificAngularMomentum.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/SpecificAngularMomentum.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.mechanics
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Kilogram
 import org.kisu.units.base.Metre
@@ -20,7 +21,7 @@ import java.math.BigDecimal
  *
  * @see SpecificAngularMomentum
  */
-typealias NewtonMetreSecondPerKilogram = Quotient<Product<Newton, Product<Metre, Second>>, Kilogram>
+typealias NewtonMetreSecondPerKilogram = Quotient<NewtonMeterSecond, Kilogram>
 
 /**
  * Measure of specific angular momentum expressed in [NewtonMetreSecondPerKilogram].
@@ -45,4 +46,13 @@ class SpecificAngularMomentum(
     magnitude,
     expression,
     ::SpecificAngularMomentum
-)
+) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(
+            magnitude,
+            Quotient(
+                Product(Newton(prefix), Product(Metre(), Second())),
+                Kilogram()
+            )
+        )
+}

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/SpecificEnergy.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/SpecificEnergy.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.mechanics
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Kilogram
 import org.kisu.units.representation.Quotient
@@ -38,4 +39,7 @@ typealias JoulePerKilogram = Quotient<Joule, Kilogram>
 class SpecificEnergy(
     magnitude: BigDecimal,
     expression: JoulePerKilogram
-) : Measure<JoulePerKilogram, SpecificEnergy>(magnitude, expression, ::SpecificEnergy)
+) : Measure<JoulePerKilogram, SpecificEnergy>(magnitude, expression, ::SpecificEnergy) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Joule(prefix), Kilogram()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/SpecificVolume.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/SpecificVolume.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.mechanics
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Kilogram
 import org.kisu.units.representation.Quotient
@@ -38,4 +39,7 @@ typealias CubicMetrePerKilogram = Quotient<CubicMetre, Kilogram>
 class SpecificVolume(
     magnitude: BigDecimal,
     expression: CubicMetrePerKilogram
-) : Measure<CubicMetrePerKilogram, SpecificVolume>(magnitude, expression, ::SpecificVolume)
+) : Measure<CubicMetrePerKilogram, SpecificVolume>(magnitude, expression, ::SpecificVolume) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(CubicMetre(prefix), Kilogram()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/SpectralIrradiance.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/SpectralIrradiance.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.mechanics
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.representation.Quotient
 import org.kisu.units.special.CubicMetre
@@ -38,4 +39,7 @@ typealias WattPerCubicMetre = Quotient<Watt, CubicMetre>
 class SpectralIrradiance(
     magnitude: BigDecimal,
     expression: WattPerCubicMetre
-) : Measure<WattPerCubicMetre, SpectralIrradiance>(magnitude, expression, ::SpectralIrradiance)
+) : Measure<WattPerCubicMetre, SpectralIrradiance>(magnitude, expression, ::SpectralIrradiance) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Watt(prefix), CubicMetre()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/SpectralPower.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/SpectralPower.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.mechanics
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Metre
 import org.kisu.units.representation.Quotient
@@ -38,4 +39,7 @@ typealias WattPerMetre = Quotient<Watt, Metre>
 class SpectralPower(
     magnitude: BigDecimal,
     expression: WattPerMetre
-) : Measure<WattPerMetre, SpectralPower>(magnitude, expression, ::SpectralPower)
+) : Measure<WattPerMetre, SpectralPower>(magnitude, expression, ::SpectralPower) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Watt(prefix), Metre()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/SpectralRadiance.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/SpectralRadiance.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.mechanics
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.representation.Product
 import org.kisu.units.representation.Quotient
@@ -40,4 +41,7 @@ typealias WattPerSteradianCubicMetre = Quotient<Watt, Product<Steradian, CubicMe
 class SpectralRadiance(
     magnitude: BigDecimal,
     expression: WattPerSteradianCubicMetre
-) : Measure<WattPerSteradianCubicMetre, SpectralRadiance>(magnitude, expression, ::SpectralRadiance)
+) : Measure<WattPerSteradianCubicMetre, SpectralRadiance>(magnitude, expression, ::SpectralRadiance) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Watt(prefix), Product(Steradian(), CubicMetre())))
+}

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/Spectralntensity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/Spectralntensity.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.mechanics
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Metre
 import org.kisu.units.representation.Product
@@ -40,4 +41,7 @@ typealias WattPerSteradianMetre = Quotient<Watt, Product<Steradian, Metre>>
 class Spectralntensity(
     magnitude: BigDecimal,
     expression: WattPerSteradianMetre
-) : Measure<WattPerSteradianMetre, Spectralntensity>(magnitude, expression, ::Spectralntensity)
+) : Measure<WattPerSteradianMetre, Spectralntensity>(magnitude, expression, ::Spectralntensity) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Watt(prefix), Product(Steradian(), Metre())))
+}

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/SurfaceTension.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/SurfaceTension.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.mechanics
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Metre
 import org.kisu.units.representation.Quotient
@@ -38,4 +39,7 @@ typealias NewtonPerMetre = Quotient<Newton, Metre>
 class SurfaceTension(
     magnitude: BigDecimal,
     expression: NewtonPerMetre
-) : Measure<NewtonPerMetre, SurfaceTension>(magnitude, expression, ::SurfaceTension)
+) : Measure<NewtonPerMetre, SurfaceTension>(magnitude, expression, ::SurfaceTension) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Newton(prefix), Metre()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/WaveNumber.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/WaveNumber.kt
@@ -26,7 +26,10 @@ import java.math.BigDecimal
 class WaveNumber(
     magnitude: BigDecimal,
     expression: ReciprocalMetre
-) : Measure<ReciprocalMetre, WaveNumber>(magnitude, expression, ::WaveNumber)
+) : Measure<ReciprocalMetre, WaveNumber>(magnitude, expression, ::WaveNumber) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, ReciprocalMetre(prefix))
+}
 
 /**
  * Unit of [WaveNumber].

--- a/lib/src/main/kotlin/org/kisu/units/photometric/Efficacy.kt
+++ b/lib/src/main/kotlin/org/kisu/units/photometric/Efficacy.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.photometric
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.representation.Quotient
 import org.kisu.units.special.Lumen
@@ -25,4 +26,7 @@ typealias LumenPerWatt = Quotient<Lumen, Watt>
 class Efficacy(
     magnitude: BigDecimal,
     expression: LumenPerWatt
-) : Measure<LumenPerWatt, Efficacy>(magnitude, expression, ::Efficacy)
+) : Measure<LumenPerWatt, Efficacy>(magnitude, expression, ::Efficacy) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Lumen(prefix), Watt()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/photometric/Exposure.kt
+++ b/lib/src/main/kotlin/org/kisu/units/photometric/Exposure.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.photometric
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Second
 import org.kisu.units.representation.Product
@@ -28,4 +29,7 @@ typealias LuxSecond = Product<Lux, Second>
 class Exposure(
     magnitude: BigDecimal,
     expression: LuxSecond
-) : Measure<LuxSecond, Exposure>(magnitude, expression, ::Exposure)
+) : Measure<LuxSecond, Exposure>(magnitude, expression, ::Exposure) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Product(Lux(prefix), Second()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/photometric/Luminance.kt
+++ b/lib/src/main/kotlin/org/kisu/units/photometric/Luminance.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.photometric
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Candela
 import org.kisu.units.representation.Quotient
@@ -30,4 +31,7 @@ typealias CandelaPerSquareMetre = Quotient<Candela, SquareMetre>
 class Luminance(
     magnitude: BigDecimal,
     expression: CandelaPerSquareMetre
-) : Measure<CandelaPerSquareMetre, Luminance>(magnitude, expression, ::Luminance)
+) : Measure<CandelaPerSquareMetre, Luminance>(magnitude, expression, ::Luminance) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Candela(prefix), SquareMetre()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/photometric/LuminousEnergy.kt
+++ b/lib/src/main/kotlin/org/kisu/units/photometric/LuminousEnergy.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.photometric
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Second
 import org.kisu.units.representation.Product
@@ -28,4 +29,7 @@ typealias LumenSecond = Product<Lumen, Second>
 class LuminousEnergy(
     magnitude: BigDecimal,
     expression: LumenSecond
-) : Measure<LumenSecond, LuminousEnergy>(magnitude, expression, ::LuminousEnergy)
+) : Measure<LumenSecond, LuminousEnergy>(magnitude, expression, ::LuminousEnergy) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Product(Lumen(prefix), Second()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/thermodynamics/HeatCapacity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/thermodynamics/HeatCapacity.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.thermodynamics
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Kelvin
 import org.kisu.units.representation.Quotient
@@ -43,4 +44,7 @@ typealias JoulePerKelvin = Quotient<Joule, Kelvin>
 class HeatCapacity(
     magnitude: BigDecimal,
     expression: JoulePerKelvin
-) : Measure<JoulePerKelvin, HeatCapacity>(magnitude, expression, ::HeatCapacity)
+) : Measure<JoulePerKelvin, HeatCapacity>(magnitude, expression, ::HeatCapacity) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Joule(prefix), Kelvin()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/thermodynamics/SpecificHeatCapacity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/thermodynamics/SpecificHeatCapacity.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.thermodynamics
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Kelvin
 import org.kisu.units.base.Kilogram
@@ -46,4 +47,13 @@ typealias JoulePerKilogramKelvin = Quotient<Joule, Product<Kilogram, Kelvin>>
 class SpecificHeatCapacity(
     magnitude: BigDecimal,
     expression: JoulePerKilogramKelvin
-) : Measure<JoulePerKilogramKelvin, SpecificHeatCapacity>(magnitude, expression, ::SpecificHeatCapacity)
+) : Measure<JoulePerKilogramKelvin, SpecificHeatCapacity>(magnitude, expression, ::SpecificHeatCapacity) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(
+            magnitude,
+            Quotient(
+                Joule(),
+                Product(Kilogram(prefix), Kelvin())
+            )
+        )
+}

--- a/lib/src/main/kotlin/org/kisu/units/thermodynamics/TemperatureGradient.kt
+++ b/lib/src/main/kotlin/org/kisu/units/thermodynamics/TemperatureGradient.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.thermodynamics
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Kelvin
 import org.kisu.units.base.Metre
@@ -43,4 +44,7 @@ typealias KelvinPerMetre = Quotient<Kelvin, Metre>
 class TemperatureGradient(
     magnitude: BigDecimal,
     expression: KelvinPerMetre
-) : Measure<KelvinPerMetre, TemperatureGradient>(magnitude, expression, ::TemperatureGradient)
+) : Measure<KelvinPerMetre, TemperatureGradient>(magnitude, expression, ::TemperatureGradient) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Kelvin(prefix), Metre()))
+}

--- a/lib/src/main/kotlin/org/kisu/units/thermodynamics/ThermalConductivity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/thermodynamics/ThermalConductivity.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.thermodynamics
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Kelvin
 import org.kisu.units.base.Metre
@@ -48,4 +49,7 @@ typealias WattPerMetreKelvin = Quotient<Watt, Product<Metre, Kelvin>>
 class ThermalConductivity(
     magnitude: BigDecimal,
     expression: WattPerMetreKelvin
-) : Measure<WattPerMetreKelvin, ThermalConductivity>(magnitude, expression, ::ThermalConductivity)
+) : Measure<WattPerMetreKelvin, ThermalConductivity>(magnitude, expression, ::ThermalConductivity) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Watt(prefix), Product(Metre(), Kelvin())))
+}

--- a/lib/src/main/kotlin/org/kisu/units/thermodynamics/ThermalExpansionCoefficient.kt
+++ b/lib/src/main/kotlin/org/kisu/units/thermodynamics/ThermalExpansionCoefficient.kt
@@ -5,6 +5,8 @@ import org.kisu.units.Measure
 import org.kisu.units.base.Kelvin
 import org.kisu.units.representation.Scalar
 import org.kisu.units.representation.Unit
+import org.kisu.units.special.PlaneAngle
+import org.kisu.units.special.Radian
 import java.math.BigDecimal
 
 /**
@@ -30,7 +32,11 @@ import java.math.BigDecimal
 class ThermalExpansionCoefficient(
     magnitude: BigDecimal,
     expression: ReciprocalKelvin
-) : Measure<ReciprocalKelvin, ThermalExpansionCoefficient>(magnitude, expression, ::ThermalExpansionCoefficient)
+) : Measure<ReciprocalKelvin, ThermalExpansionCoefficient>(magnitude, expression, ::ThermalExpansionCoefficient) {
+
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, ReciprocalKelvin(prefix))
+}
 
 /**
  * Represents the **reciprocal of temperature** in the SI system.

--- a/lib/src/main/kotlin/org/kisu/units/thermodynamics/ThermalExpansionCoefficient.kt
+++ b/lib/src/main/kotlin/org/kisu/units/thermodynamics/ThermalExpansionCoefficient.kt
@@ -5,8 +5,6 @@ import org.kisu.units.Measure
 import org.kisu.units.base.Kelvin
 import org.kisu.units.representation.Scalar
 import org.kisu.units.representation.Unit
-import org.kisu.units.special.PlaneAngle
-import org.kisu.units.special.Radian
 import java.math.BigDecimal
 
 /**

--- a/lib/src/main/kotlin/org/kisu/units/thermodynamics/ThermalResistance.kt
+++ b/lib/src/main/kotlin/org/kisu/units/thermodynamics/ThermalResistance.kt
@@ -1,5 +1,6 @@
 package org.kisu.units.thermodynamics
 
+import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Kelvin
 import org.kisu.units.representation.Quotient
@@ -45,4 +46,7 @@ typealias KelvinPerWatt = Quotient<Kelvin, Watt>
 class ThermalResistance(
     magnitude: BigDecimal,
     expression: KelvinPerWatt
-) : Measure<KelvinPerWatt, ThermalResistance>(magnitude, expression, ::ThermalResistance)
+) : Measure<KelvinPerWatt, ThermalResistance>(magnitude, expression, ::ThermalResistance) {
+    internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
+        this(magnitude, Quotient(Kelvin(prefix), Watt()))
+}

--- a/lib/src/test/kotlin/org/kisu/units/base/LengthTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/base/LengthTest.kt
@@ -10,12 +10,12 @@ import io.kotest.property.checkAll
 import org.kisu.bigDecimal
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
-import org.kisu.units.builders.meters
+import org.kisu.units.builders.metres
 
 class LengthTest : StringSpec({
     "creates Length" {
         checkAll(Arb.long().filter { it != 0L }, MetricBuilders.generator) { magnitude, builder ->
-            magnitude.builder().meters.should { (amount, expression, symbol) ->
+            magnitude.builder().metres.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude.bigDecimal
                 expression shouldBe Metre(magnitude.builder().metric)
                 symbol shouldBe Metre.UNIT.toString()

--- a/lib/src/test/kotlin/org/kisu/units/base/LengthTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/base/LengthTest.kt
@@ -25,7 +25,7 @@ class LengthTest : StringSpec({
 
     "creates a base Length" {
         checkAll(Arb.bigDecimal()) { magnitude ->
-            magnitude.meters.should { (amount, expression, symbol) ->
+            magnitude.metres.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude.bigDecimal
                 expression shouldBe Metre()
                 symbol shouldBe Metre.UNIT.toString()

--- a/lib/src/test/kotlin/org/kisu/units/special/AreaTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/special/AreaTest.kt
@@ -22,7 +22,7 @@ class AreaTest : StringSpec({
 
     "creates a base Area" {
         checkAll(Arb.bigDecimal()) { magnitude ->
-            magnitude.squareMeters.should { (amount, expression, symbol) ->
+            magnitude.squareMetres.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
                 expression shouldBe SquareMetre()
                 symbol shouldBe SquareMetre.UNIT.toString()

--- a/lib/src/test/kotlin/org/kisu/units/special/AreaTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/special/AreaTest.kt
@@ -7,12 +7,12 @@ import io.kotest.property.Arb
 import io.kotest.property.checkAll
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
-import org.kisu.units.builders.squareMeters
+import org.kisu.units.builders.squareMetres
 
 class AreaTest : StringSpec({
     "creates an Area" {
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
-            magnitude.builder().squareMeters.should { (amount, expression, symbol) ->
+            magnitude.builder().squareMetres.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
                 expression shouldBe SquareMetre(magnitude.builder().metric)
                 symbol shouldBe SquareMetre.UNIT.toString()

--- a/lib/src/test/kotlin/org/kisu/units/special/VolumeTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/special/VolumeTest.kt
@@ -22,7 +22,7 @@ class VolumeTest : StringSpec({
 
     "creates a base Volume" {
         checkAll(Arb.bigDecimal()) { magnitude ->
-            magnitude.cubicMeters.should { (amount, expression, symbol) ->
+            magnitude.cubicMetres.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
                 expression shouldBe CubicMetre()
                 symbol shouldBe CubicMetre.UNIT.toString()

--- a/lib/src/test/kotlin/org/kisu/units/special/VolumeTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/special/VolumeTest.kt
@@ -7,12 +7,12 @@ import io.kotest.property.Arb
 import io.kotest.property.checkAll
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
-import org.kisu.units.builders.cubicMeters
+import org.kisu.units.builders.cubicMetres
 
 class VolumeTest : StringSpec({
     "creates a Volume" {
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
-            magnitude.builder().cubicMeters.should { (amount, expression, symbol) ->
+            magnitude.builder().cubicMetres.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
                 expression shouldBe CubicMetre(magnitude.builder().metric)
                 symbol shouldBe CubicMetre.UNIT.toString()


### PR DESCRIPTION
 
## 🐞 Problem to Solve

This PR introduces **creators for the metric builders of derived units**.  
Until now, metric builders were only available for base units, which made it less convenient to construct measures for derived quantities (e.g., velocity, force, energy).  

## 💡 Solution

With this change:
- Derived units can now be instantiated using metric builders in a consistent way.
- Code readability and discoverability improve, as the syntax follows the same convention as for base units.

---
  
  ✅ **Checklist**

- [X] The PR includes a clear and descriptive title
- [X] Related issue(s) are linked in the PR body
- [X] The solution is explained thoroughly
- [X] Tests or proofs are included

