### PR TITLE
[KISU-85] Fixes Kilogram issues

### DIFF
--- a/lib/src/main/kotlin/org/kisu/units/base/Mass.kt
+++ b/lib/src/main/kotlin/org/kisu/units/base/Mass.kt
@@ -1,6 +1,7 @@
 package org.kisu.units.base
 
 import org.kisu.prefixes.Metric
+import org.kisu.prefixes.times
 import org.kisu.units.Measure
 import org.kisu.units.representation.Scalar
 import org.kisu.units.representation.Unit
@@ -26,13 +27,20 @@ class Mass internal constructor(magnitude: BigDecimal, expression: Kilogram) :
     Measure<Kilogram, Mass>(magnitude, expression, ::Mass) {
 
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.KILO) :
-        this(magnitude, Kilogram(prefix))
+        this(magnitude, Kilogram(prefix to BigDecimal.ONE))
 }
 
 /**
  * Represents the SI base unit of **mass**.
  *
- * The kilogram (kg) is the standard unit for measuring mass.
+ * The kilogram (kg) is the SI base unit for mass.
+ *
+ * Internally, this class normalizes to grams (g) so that metric
+ * prefixes work consistently:
+ * - Kilogram(Metric.BASE) = 1 kg
+ * - Kilogram(Metric.KILO) = 1 Mg
+ * - Kilogram(Metric.MILLI) = 1 g
+ * - Kilogram(Metric.MICRO) = 1 mg
  */
 class Kilogram private constructor(
     prefix: Metric,
@@ -40,10 +48,12 @@ class Kilogram private constructor(
     unit: Unit
 ) : Scalar<Metric, Kilogram>(prefix, overflow, unit, ::Kilogram) {
 
-    constructor(prefix: Metric = Metric.BASE) : this(prefix, BigDecimal.ONE, UNIT)
+    constructor(pair: Pair<Metric, BigDecimal>) : this(pair.first, pair.second, UNIT)
+
+    constructor(prefix: Metric = Metric.BASE) : this(prefix * Metric.KILO)
 
     companion object {
-        /** The canonical SI symbol for mass: "kg". */
+        /** The canonical unit symbol used internally: "g". */
         internal val UNIT = Unit("g", 1)
     }
 }

--- a/lib/src/main/kotlin/org/kisu/units/builders/MetricUnitBuilder.kt
+++ b/lib/src/main/kotlin/org/kisu/units/builders/MetricUnitBuilder.kt
@@ -351,6 +351,83 @@ val MetricUnitBuilder.faradPerMetre: Permittivity
 val MetricUnitBuilder.farads: Capacitance get() = Capacitance(magnitude, metric)
 
 /**
+ * Creates a [Yank] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val yank = 1.kilo.gramMetre // 1 kg·m/s³
+ * ```
+ */
+val MetricUnitBuilder.gramMetre: Yank
+    get() = Yank(magnitude, metric)
+
+/**
+ * Creates a [Yank] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val yank = 1.kilo.gramMetreSecondThird // 1 kg·m/s³
+ * ```
+ */
+val MetricUnitBuilder.gramMetreSecondThird: Yank
+    get() = Yank(magnitude, metric)
+
+/**
+ * Creates a [Density] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val density = 1.kilo.gramPerCubicMetre // 1 kg/m³
+ * ```
+ */
+val MetricUnitBuilder.gramPerCubicMetre: Density
+    get() = Density(magnitude, metric)
+
+/**
+ * Creates a [LinearMassDensity] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val linearMassDensity = 1.kilo.gramPerMetre // 1 kg/m
+ * ```
+ */
+val MetricUnitBuilder.gramPerMetre: LinearMassDensity
+    get() = LinearMassDensity(magnitude, metric)
+
+/**
+ * Creates a [MolarMass] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val molarMass = 1.kilo.gramPerMole // 1 kg/mol
+ * ```
+ */
+val MetricUnitBuilder.gramPerMole: MolarMass
+    get() = MolarMass(magnitude, metric)
+
+/**
+ * Creates a [MassFlowRate] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val massFlow = 1.kilo.gramPerSecond // 1 kg/s
+ * ```
+ */
+val MetricUnitBuilder.gramPerSecond: MassFlowRate
+    get() = MassFlowRate(magnitude, metric)
+
+/**
+ * Creates an [AreaDensity] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val areaDensity = 1.kilo.gramPerSquareMetre // 1 kg/m²
+ * ```
+ */
+val MetricUnitBuilder.gramPerSquareMetre: AreaDensity
+    get() = AreaDensity(magnitude, metric)
+
+/**
  * Creates a [Mass] measure by applying the metric prefix scale to the magnitude.
  *
  * Note: The SI base unit is kilogram, but this treats grams as base unit with prefix scaling.
@@ -361,6 +438,17 @@ val MetricUnitBuilder.farads: Capacitance get() = Capacitance(magnitude, metric)
  * ```
  */
 val MetricUnitBuilder.grams: Mass get() = Mass(magnitude, metric)
+
+/**
+ * Creates a [MomentOfIntertia] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val inertia = 1.kilo.gramSquareMetre // 1 kg·m²
+ * ```
+ */
+val MetricUnitBuilder.gramSquareMetre: MomentOfIntertia
+    get() = MomentOfIntertia(magnitude, metric)
 
 /**
  * Creates an [AbsorbedDoseRate] measure by applying the metric prefix scale to the magnitude.
@@ -586,94 +674,6 @@ val MetricUnitBuilder.kelvinPerWatt: ThermalResistance
  * ```
  */
 val MetricUnitBuilder.kelvins: Temperature get() = Temperature(magnitude, metric)
-
-/**
- * Creates a [Yank] measure by applying the metric prefix scale to the magnitude.
- *
- * Example usage:
- * ```
- * val yank = 1.kilogramMetre // 1 kg·m/s³
- * ```
- */
-val MetricUnitBuilder.kilogramMetre: Yank
-    get() = Yank(magnitude, metric)
-
-/**
- * Creates a [Yank] measure by applying the metric prefix scale to the magnitude.
- *
- * Example usage:
- * ```
- * val yank = 1.kilogramMetreSecondThird // 1 kg·m/s³
- * ```
- */
-val MetricUnitBuilder.kilogramMetreSecondThird: Yank
-    get() = Yank(magnitude, metric)
-
-/**
- * Creates a [Density] measure by applying the metric prefix scale to the magnitude.
- *
- * Example usage:
- * ```
- * val density = 1.kilogramPerCubicMetre // 1 kg/m³
- * ```
- */
-val MetricUnitBuilder.kilogramPerCubicMetre: Density
-    get() = Density(magnitude, metric)
-
-/**
- * Creates a [LinearMassDensity] measure by applying the metric prefix scale to the magnitude.
- *
- * Example usage:
- * ```
- * val linearMassDensity = 1.kilogramPerMetre // 1 kg/m
- * ```
- */
-val MetricUnitBuilder.kilogramPerMetre: LinearMassDensity
-    get() = LinearMassDensity(magnitude, metric)
-
-/**
- * Creates a [MolarMass] measure by applying the metric prefix scale to the magnitude.
- *
- * Example usage:
- * ```
- * val molarMass = 1.kilogramPerMole // 1 kg/mol
- * ```
- */
-val MetricUnitBuilder.kilogramPerMole: MolarMass
-    get() = MolarMass(magnitude, metric)
-
-/**
- * Creates a [MassFlowRate] measure by applying the metric prefix scale to the magnitude.
- *
- * Example usage:
- * ```
- * val massFlow = 1.kilogramPerSecond // 1 kg/s
- * ```
- */
-val MetricUnitBuilder.kilogramPerSecond: MassFlowRate
-    get() = MassFlowRate(magnitude, metric)
-
-/**
- * Creates an [AreaDensity] measure by applying the metric prefix scale to the magnitude.
- *
- * Example usage:
- * ```
- * val areaDensity = 1.kilogramPerSquareMetre // 1 kg/m²
- * ```
- */
-val MetricUnitBuilder.kilogramPerSquareMetre: AreaDensity
-    get() = AreaDensity(magnitude, metric)
-
-/**
- * Creates a [MomentOfIntertia] measure by applying the metric prefix scale to the magnitude.
- *
- * Example usage:
- * ```
- * val inertia = 1.kilogramSquareMetre // 1 kg·m²
- * ```
- */
-val MetricUnitBuilder.kilogramSquareMetre: MomentOfIntertia
-    get() = MomentOfIntertia(magnitude, metric)
 
 /**
  * Creates an [Efficacy] measure by applying the metric prefix scale to the magnitude.

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/MolarMass.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/MolarMass.kt
@@ -45,5 +45,5 @@ class MolarMass(
     expression: KilogramPerMole
 ) : Measure<KilogramPerMole, MolarMass>(magnitude, expression, ::MolarMass) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
-        this(magnitude, Quotient(Kilogram(prefix), Mole()))
+        this(magnitude, Quotient(Kilogram(prefix to BigDecimal.ONE), Mole()))
 }

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/Yank.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/Yank.kt
@@ -38,7 +38,7 @@ class Yank internal constructor(
         this(
             magnitude,
             Quotient(
-                Product(Kilogram(prefix), Metre()),
+                Product(Kilogram(prefix to BigDecimal.ONE), Metre()),
                 SecondCubed()
             )
         )

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/AreaDensity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/AreaDensity.kt
@@ -40,5 +40,5 @@ class AreaDensity(
     expression: KilogramPerSquareMetre
 ) : Measure<KilogramPerSquareMetre, AreaDensity>(magnitude, expression, ::AreaDensity) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
-        this(magnitude, Quotient(Kilogram(prefix), SquareMetre()))
+        this(magnitude, Quotient(Kilogram(prefix to BigDecimal.ONE), SquareMetre()))
 }

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/Density.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/Density.kt
@@ -40,5 +40,5 @@ class Density(
     expression: KilogramPerCubicMetre
 ) : Measure<KilogramPerCubicMetre, Density>(magnitude, expression, ::Density) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
-        this(magnitude, Quotient(Kilogram(prefix), CubicMetre()))
+        this(magnitude, Quotient(Kilogram(prefix to BigDecimal.ONE), CubicMetre()))
 }

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/LinearMassDensity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/LinearMassDensity.kt
@@ -40,5 +40,5 @@ class LinearMassDensity(
     expression: KilogramPerMetre
 ) : Measure<KilogramPerMetre, LinearMassDensity>(magnitude, expression, ::LinearMassDensity) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
-        this(magnitude, Quotient(Kilogram(prefix), Metre()))
+        this(magnitude, Quotient(Kilogram(prefix to BigDecimal.ONE), Metre()))
 }

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/MassFlowRate.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/MassFlowRate.kt
@@ -40,5 +40,5 @@ class MassFlowRate(
     expression: KilogramPerSecond
 ) : Measure<KilogramPerSecond, MassFlowRate>(magnitude, expression, ::MassFlowRate) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
-        this(magnitude, Quotient(Kilogram(prefix), Second()))
+        this(magnitude, Quotient(Kilogram(prefix to BigDecimal.ONE), Second()))
 }

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/MomentOfIntertia.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/MomentOfIntertia.kt
@@ -41,5 +41,5 @@ class MomentOfIntertia(
     expression: KilogramSquareMetre
 ) : Measure<KilogramSquareMetre, MomentOfIntertia>(magnitude, expression, ::MomentOfIntertia) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
-        this(magnitude, Product(Kilogram(prefix), SquareMetre()))
+        this(magnitude, Product(Kilogram(prefix to BigDecimal.ONE), SquareMetre()))
 }

--- a/lib/src/test/kotlin/org/kisu/units/base/KilogramTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/base/KilogramTest.kt
@@ -1,0 +1,21 @@
+package org.kisu.units.base
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.ints.shouldBeZero
+import io.kotest.matchers.shouldBe
+import io.kotest.property.checkAll
+import org.kisu.prefixes.Metric
+import org.kisu.prefixes.times
+import org.kisu.test.generators.Metrics
+
+class KilogramTest : StringSpec({
+    "kilogram corrects the metric prefix" {
+        checkAll(Metrics.generator) { prefix ->
+            val (newPrefix, overflow) = prefix * Metric.KILO
+            val kilos = Kilogram(prefix)
+
+            kilos.symbol shouldBe "${newPrefix}g"
+            (kilos.factor / newPrefix.factor).compareTo(overflow).shouldBeZero()
+        }
+    }
+})

--- a/lib/src/test/kotlin/org/kisu/units/base/MassTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/base/MassTest.kt
@@ -5,16 +5,18 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.checkAll
+import org.kisu.prefixes.Metric
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
 import org.kisu.units.builders.grams
+import java.math.BigDecimal
 
 class MassTest : StringSpec({
     "creates mass" {
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
             magnitude.builder().grams.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe Kilogram(magnitude.builder().metric)
+                expression shouldBe Kilogram(magnitude.builder().metric to BigDecimal.ONE)
                 symbol shouldBe Kilogram.UNIT.toString()
             }
         }
@@ -24,7 +26,7 @@ class MassTest : StringSpec({
         checkAll(Arb.bigDecimal()) { magnitude ->
             magnitude.grams.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
-                expression shouldBe Kilogram()
+                expression shouldBe Kilogram(Metric.BASE to BigDecimal.ONE)
                 symbol shouldBe Kilogram.UNIT.toString()
             }
         }


### PR DESCRIPTION
Closes #85 
## 🐞 Problem to Solve

This PR introduces proper handling of **kilogram as the SI base unit** while keeping prefix operations consistent with the rest of the metric system.  

Since the kilogram is defined with the `kilo` prefix already applied, special care was needed to ensure calculations and overflows behave correctly.

## 💡 Solution

- Modified `Kilogram` class extending `Scalar<Metric, Kilogram>`.
- Internally stores mass in grams (`g`), making prefix scaling straightforward.
- Provides multiple constructors:
  - `Kilogram(Metric.BASE)` → `1 kg`
  - `Kilogram(Metric.KILO)` → `1 Mg`
  - `Kilogram(Metric.MILLI)` → `1 g`
  - `Kilogram(Metric.MICRO)` → `1 mg`
- Companion object defines `UNIT = "g"` as the canonical internal symbol.

### Motivation
Mass is unique among SI base units because the kilogram (`kg`) is defined as the base, not the gram.  
To avoid inconsistencies with metric prefix scaling, this implementation internally treats **gram (`g`) as the normalized unit**, while still presenting `kg` as the SI base to users.

### Example Usage
```kotlin
val oneKg = Kilogram(Metric.BASE)   // 1 kg
val oneMg = Kilogram(Metric.KILO)   // 1 Mg
val oneGram = Kilogram(Metric.MILLI) // 1 g
val oneMilligram = Kilogram(Metric.MICRO) // 1 mg
```

---
  
  ✅ **Checklist**

- [X] The PR includes a clear and descriptive title
- [X] Related issue(s) are linked in the PR body
- [X] The solution is explained thoroughly
- [X] Tests or proofs are included

