### PR TITLE
[KISU-92] Use nested aliases for complex units in derived units

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,11 @@ jobs:
           restore-keys: |
             gradle-${{ runner.os }}-
 
-      - name: Set up JDK 19
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 19
+          java-version: 21
 
       - name: Grant execute permission for Gradle
         run: chmod +x ./gradlew

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ detekt = "1.23.8"
 dokka = "2.0.0"
 jacoco = "0.8.13"
 klint = "12.3.0"
-kotest = "6.0.0"
+kotest = "6.0.2"
 
 [plugins]
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt"}

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -1,4 +1,5 @@
 import io.gitlab.arturbosch.detekt.Detekt
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     kotlin("jvm")
@@ -41,6 +42,10 @@ dependencies {
 
 kotlin {
     jvmToolchain(19)
+    compilerOptions {
+        freeCompilerArgs.add("-Xnested-type-aliases")
+        languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_2)
+    }
 }
 
 dokka {
@@ -55,4 +60,9 @@ dokka {
             footerMessage.set("(c) Sefford & Patri-create 2025")
         }
     }
+}
+
+val compileKotlin: KotlinCompile by tasks
+compileKotlin.compilerOptions {
+    freeCompilerArgs.set(listOf("-Xnested-type-aliases"))
 }

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/CatalyticEfficiency.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/CatalyticEfficiency.kt
@@ -4,50 +4,12 @@ import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Mole
 import org.kisu.units.base.Second
+import org.kisu.units.chemistry.CatalyticEfficiency.Companion.CubicMetrePerMoleSecond
 import org.kisu.units.representation.Product
 import org.kisu.units.representation.Quotient
 import org.kisu.units.special.CubicMetre
 import org.kisu.units.special.SquareMetre
 import java.math.BigDecimal
-
-/**
- * Represents the SI unit **cubic metre per mole second (m³/(mol·s))**.
- *
- * This unit is used to measure **catalytic efficiency**, i.e., the volume of
- * substrate converted per mole of catalyst per second.
- * It is defined as the [Quotient] of [SquareMetre] (area) divided by the [Product]
- * of [Mole] (amount of substance) and [Second] (time).
- *
- * Example usages include:
- * - Characterising enzyme or catalyst performance in chemical reactions
- * - Determining turnover rates in biochemistry and industrial catalysis
- *
- * @see CatalyticEfficiency for the physical quantity represented by this unit.
- */
-typealias CubicMetrePerMoleSecond = Quotient<CubicMetre, Product<Mole, Second>>
-
-/**
- * Creates a measure of **cubic metres per mole-second** (m³/(mol·s)).
- *
- * This is a derived unit commonly used in chemistry and related
- * disciplines for expressing volumetric quantities per substance
- * amount per unit of time.
- *
- * Internally this returns a [Quotient] of:
- *  - a [CubicMetre] (volume) with the specified [prefix]
- *  - divided by a [Product] of [Mole] (amount of substance)
- *    and [Second] (time)
- *
- * @param prefix Metric prefix to apply to the cubic metre unit.
- * Defaults to [Metric.BASE] (no prefix).
- *
- * @return A [CubicMetrePerMoleSecond] representing m³/(mol·s).
- */
-@Suppress("FunctionNaming")
-internal fun CubicMetrePerMoleSecond(prefix: Metric = Metric.BASE): CubicMetrePerMoleSecond = Quotient(
-    CubicMetre(prefix),
-    Product(Mole(), Second())
-)
 
 /**
  * Represents the physical quantity of **catalytic efficiency**.
@@ -76,11 +38,56 @@ internal fun CubicMetrePerMoleSecond(prefix: Metric = Metric.BASE): CubicMetrePe
 class CatalyticEfficiency(
     magnitude: BigDecimal,
     expression: CubicMetrePerMoleSecond
-) : Measure<CubicMetrePerMoleSecond, CatalyticEfficiency>(magnitude, expression, ::CatalyticEfficiency) {
+) : Measure<CatalyticEfficiency.CubicMetrePerMoleSecond, CatalyticEfficiency>(
+    magnitude = magnitude,
+    expression = expression,
+    create = ::CatalyticEfficiency
+) {
 
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(
             magnitude,
             CubicMetrePerMoleSecond(prefix)
         )
+
+    /**
+     * Represents the SI unit **cubic metre per mole second (m³/(mol·s))**.
+     *
+     * This unit is used to measure **catalytic efficiency**, i.e., the volume of
+     * substrate converted per mole of catalyst per second.
+     * It is defined as the [Quotient] of [SquareMetre] (area) divided by the [Product]
+     * of [Mole] (amount of substance) and [Second] (time).
+     *
+     * Example usages include:
+     * - Characterising enzyme or catalyst performance in chemical reactions
+     * - Determining turnover rates in biochemistry and industrial catalysis
+     *
+     * @see CatalyticEfficiency for the physical quantity represented by this unit.
+     */
+    typealias CubicMetrePerMoleSecond = Quotient<CubicMetre, Product<Mole, Second>>
+
+    companion object {
+        /**
+         * Creates a measure of **cubic metres per mole-second** (m³/(mol·s)).
+         *
+         * This is a derived unit commonly used in chemistry and related
+         * disciplines for expressing volumetric quantities per substance
+         * amount per unit of time.
+         *
+         * Internally this returns a [Quotient] of:
+         *  - a [CubicMetre] (volume) with the specified [prefix]
+         *  - divided by a [Product] of [Mole] (amount of substance)
+         *    and [Second] (time)
+         *
+         * @param prefix Metric prefix to apply to the cubic metre unit.
+         * Defaults to [Metric.BASE] (no prefix).
+         *
+         * @return A [CubicMetrePerMoleSecond] representing m³/(mol·s).
+         */
+        @Suppress("FunctionNaming")
+        internal fun CubicMetrePerMoleSecond(prefix: Metric = Metric.BASE): CubicMetrePerMoleSecond = Quotient(
+            CubicMetre(prefix),
+            Product(Mole(), Second())
+        )
+    }
 }

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/Molality.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/Molality.kt
@@ -8,40 +8,6 @@ import org.kisu.units.representation.Quotient
 import java.math.BigDecimal
 
 /**
- * Represents the SI unit **mole per kilogram (mol/kg)**.
- *
- * This unit measures **molality**, i.e., the amount of substance per unit mass
- * of solvent.
- * It is defined as the [Quotient] of [Mole] (amount of substance) divided by [Kilogram] (mass).
- *
- * Example usages include:
- * - Expressing solute concentration in chemistry and chemical engineering
- * - Thermodynamic calculations involving colligative properties
- *
- * @see Molality for the physical quantity represented by this unit.
- */
-typealias MolPerKilogram = Quotient<Mole, Kilogram>
-
-/**
- * Creates a measure of **moles per kilogram** (mol/kg).
- *
- * This derived unit is commonly used in chemistry to express
- * the amount of substance per unit mass of a solvent or solution.
- *
- * Internally this returns a [Quotient] of:
- *  - a [Mole] (amount of substance) with the specified [prefix]
- *  - divided by a [Kilogram] (mass)
- *
- * @param prefix Metric prefix to apply to the mole unit.
- * Defaults to [Metric.BASE] (no prefix).
- *
- * @return A [Quotient] representing mol/kg.
- */
-@Suppress("FunctionNaming")
-internal fun MolPerKilogram(prefix: Metric = Metric.BASE): Quotient<Mole, Kilogram> =
-    Quotient(Mole(prefix), Kilogram())
-
-/**
  * Represents the physical quantity of **molality**.
  *
  * Molality quantifies the **amount of substance of solute per unit mass of solvent**.
@@ -64,8 +30,44 @@ internal fun MolPerKilogram(prefix: Metric = Metric.BASE): Quotient<Mole, Kilogr
 class Molality(
     magnitude: BigDecimal,
     expression: MolPerKilogram
-) : Measure<MolPerKilogram, Molality>(magnitude, expression, ::Molality) {
+) : Measure<Molality.MolPerKilogram, Molality>(magnitude, expression, ::Molality) {
 
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, MolPerKilogram(prefix))
+
+    /**
+     * Represents the SI unit **mole per kilogram (mol/kg)**.
+     *
+     * This unit measures **molality**, i.e., the amount of substance per unit mass
+     * of solvent.
+     * It is defined as the [Quotient] of [Mole] (amount of substance) divided by [Kilogram] (mass).
+     *
+     * Example usages include:
+     * - Expressing solute concentration in chemistry and chemical engineering
+     * - Thermodynamic calculations involving colligative properties
+     *
+     * @see Molality for the physical quantity represented by this unit.
+     */
+    typealias MolPerKilogram = Quotient<Mole, Kilogram>
+
+    companion object {
+        /**
+         * Creates a measure of **moles per kilogram** (mol/kg).
+         *
+         * This derived unit is commonly used in chemistry to express
+         * the amount of substance per unit mass of a solvent or solution.
+         *
+         * Internally this returns a [Quotient] of:
+         *  - a [Mole] (amount of substance) with the specified [prefix]
+         *  - divided by a [Kilogram] (mass)
+         *
+         * @param prefix Metric prefix to apply to the mole unit.
+         * Defaults to [Metric.BASE] (no prefix).
+         *
+         * @return A [Quotient] representing mol/kg.
+         */
+        @Suppress("FunctionNaming")
+        internal fun MolPerKilogram(prefix: Metric = Metric.BASE): Quotient<Mole, Kilogram> =
+            Quotient(Mole(prefix), Kilogram())
+    }
 }

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/MolarConductivity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/MolarConductivity.kt
@@ -3,51 +3,12 @@ package org.kisu.units.chemistry
 import org.kisu.prefixes.Metric
 import org.kisu.units.Measure
 import org.kisu.units.base.Mole
+import org.kisu.units.chemistry.MolarConductivity.Companion.SiemensSquareMetrePerMole
 import org.kisu.units.representation.Product
 import org.kisu.units.representation.Quotient
 import org.kisu.units.special.Siemens
 import org.kisu.units.special.SquareMetre
 import java.math.BigDecimal
-
-/**
- * Represents the SI unit **siemens square metre per mole (S·m²/mol)**.
- *
- * This unit is used to measure **molar conductivity**, i.e., the electrical
- * conductivity of an electrolyte solution normalized by its molar concentration.
- * It is defined as the [Quotient] of the [Product] of [Siemens] (conductance) and
- * [SquareMetre] (area) divided by [Mole] (amount of substance).
- *
- * Example usages include:
- * - Determining ion mobility in electrolyte solutions
- * - Characterising strong and weak electrolytes
- * - Electrochemistry and materials science applications
- *
- * @see MolarConductivity for the physical quantity represented by this unit.
- */
-typealias SiemensSquareMetrePerMole = Quotient<Product<Siemens, SquareMetre>, Mole>
-
-/**
- * Creates a measure of **siemens square metres per mole** (S·m²/mol).
- *
- * This derived unit can be used in electrochemistry and related
- * fields to express conductivity–area products per amount of substance.
- *
- * Internally this returns a [Quotient] of:
- *  - a [Product] of [Siemens] (electrical conductance) with the specified [prefix]
- *    and [SquareMetre] (area)
- *  - divided by a [Mole] (amount of substance)
- *
- * @param prefix Metric prefix to apply to the siemens unit.
- * Defaults to [Metric.BASE] (no prefix).
- *
- * @return A [Quotient] representing S·m²/mol.
- */
-@Suppress("FunctionNaming")
-internal fun SiemensSquareMetrePerMole(prefix: Metric = Metric.BASE): Quotient<Product<Siemens, SquareMetre>, Mole> =
-    Quotient(
-        Product(Siemens(prefix), SquareMetre()),
-        Mole()
-    )
 
 /**
  * Represents the physical quantity of **molar conductivity**.
@@ -74,11 +35,59 @@ internal fun SiemensSquareMetrePerMole(prefix: Metric = Metric.BASE): Quotient<P
 class MolarConductivity(
     magnitude: BigDecimal,
     expression: SiemensSquareMetrePerMole
-) : Measure<SiemensSquareMetrePerMole, MolarConductivity>(magnitude, expression, ::MolarConductivity) {
+) : Measure<MolarConductivity.SiemensSquareMetrePerMole, MolarConductivity>(
+    magnitude = magnitude,
+    expression = expression,
+    create = ::MolarConductivity
+) {
 
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(
             magnitude,
             SiemensSquareMetrePerMole(prefix)
         )
+
+    /**
+     * Represents the SI unit **siemens square metre per mole (S·m²/mol)**.
+     *
+     * This unit is used to measure **molar conductivity**, i.e., the electrical
+     * conductivity of an electrolyte solution normalized by its molar concentration.
+     * It is defined as the [Quotient] of the [Product] of [Siemens] (conductance) and
+     * [SquareMetre] (area) divided by [Mole] (amount of substance).
+     *
+     * Example usages include:
+     * - Determining ion mobility in electrolyte solutions
+     * - Characterising strong and weak electrolytes
+     * - Electrochemistry and materials science applications
+     *
+     * @see MolarConductivity for the physical quantity represented by this unit.
+     */
+    typealias SiemensSquareMetrePerMole = Quotient<Product<Siemens, SquareMetre>, Mole>
+
+    companion object {
+        /**
+         * Creates a measure of **siemens square metres per mole** (S·m²/mol).
+         *
+         * This derived unit can be used in electrochemistry and related
+         * fields to express conductivity–area products per amount of substance.
+         *
+         * Internally this returns a [Quotient] of:
+         *  - a [Product] of [Siemens] (electrical conductance) with the specified [prefix]
+         *    and [SquareMetre] (area)
+         *  - divided by a [Mole] (amount of substance)
+         *
+         * @param prefix Metric prefix to apply to the siemens unit.
+         * Defaults to [Metric.BASE] (no prefix).
+         *
+         * @return A [Quotient] representing S·m²/mol.
+         */
+        @Suppress("FunctionNaming")
+        internal fun SiemensSquareMetrePerMole(
+            prefix: Metric = Metric.BASE
+        ): Quotient<Product<Siemens, SquareMetre>, Mole> =
+            Quotient(
+                Product(Siemens(prefix), SquareMetre()),
+                Mole()
+            )
+    }
 }

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/MolarEnergy.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/MolarEnergy.kt
@@ -8,41 +8,6 @@ import org.kisu.units.special.Joule
 import java.math.BigDecimal
 
 /**
- * Represents the SI unit **joule per mole (J/mol)**.
- *
- * This unit measures **molar energy**, i.e., the amount of energy associated
- * with one mole of a substance.
- * It is defined as the [Quotient] of [Joule] (energy) divided by [Mole] (amount of substance).
- *
- * Example usages include:
- * - Enthalpy of reaction (ΔH, in J/mol)
- * - Gibbs free energy (ΔG, in J/mol)
- * - Energy per mole for phase transitions or chemical reactions
- *
- * @see MolarEnergy for the physical quantity represented by this unit.
- */
-typealias JoulePerMole = Quotient<Joule, Mole>
-
-/**
- * Creates a measure of **joules per mole** (J/mol).
- *
- * This derived unit is widely used in chemistry and thermodynamics
- * to express energy, work or enthalpy per amount of substance.
- *
- * Internally this returns a [Quotient] of:
- *  - a [Joule] (energy) with the specified [prefix]
- *  - divided by a [Mole] (amount of substance)
- *
- * @param prefix Metric prefix to apply to the joule unit.
- * Defaults to [Metric.BASE] (no prefix).
- *
- * @return A [Quotient] representing J/mol.
- */
-@Suppress("FunctionNaming")
-internal fun JoulePerMole(prefix: Metric = Metric.BASE): Quotient<Joule, Mole> =
-    Quotient(Joule(prefix), Mole())
-
-/**
  * Represents the physical quantity of **molar energy**.
  *
  * Molar energy quantifies the **amount of energy per mole of substance**.
@@ -65,8 +30,45 @@ internal fun JoulePerMole(prefix: Metric = Metric.BASE): Quotient<Joule, Mole> =
 class MolarEnergy(
     magnitude: BigDecimal,
     expression: JoulePerMole
-) : Measure<JoulePerMole, MolarEnergy>(magnitude, expression, ::MolarEnergy) {
+) : Measure<MolarEnergy.JoulePerMole, MolarEnergy>(magnitude, expression, ::MolarEnergy) {
 
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, JoulePerMole(prefix))
+
+    /**
+     * Represents the SI unit **joule per mole (J/mol)**.
+     *
+     * This unit measures **molar energy**, i.e., the amount of energy associated
+     * with one mole of a substance.
+     * It is defined as the [Quotient] of [Joule] (energy) divided by [Mole] (amount of substance).
+     *
+     * Example usages include:
+     * - Enthalpy of reaction (ΔH, in J/mol)
+     * - Gibbs free energy (ΔG, in J/mol)
+     * - Energy per mole for phase transitions or chemical reactions
+     *
+     * @see MolarEnergy for the physical quantity represented by this unit.
+     */
+    typealias JoulePerMole = Quotient<Joule, Mole>
+
+    companion object {
+        /**
+         * Creates a measure of **joules per mole** (J/mol).
+         *
+         * This derived unit is widely used in chemistry and thermodynamics
+         * to express energy, work or enthalpy per amount of substance.
+         *
+         * Internally this returns a [Quotient] of:
+         *  - a [Joule] (energy) with the specified [prefix]
+         *  - divided by a [Mole] (amount of substance)
+         *
+         * @param prefix Metric prefix to apply to the joule unit.
+         * Defaults to [Metric.BASE] (no prefix).
+         *
+         * @return A [Quotient] representing J/mol.
+         */
+        @Suppress("FunctionNaming")
+        internal fun JoulePerMole(prefix: Metric = Metric.BASE): Quotient<Joule, Mole> =
+            Quotient(Joule(prefix), Mole())
+    }
 }

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/MolarHeatCapacity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/MolarHeatCapacity.kt
@@ -10,46 +10,6 @@ import org.kisu.units.special.Joule
 import java.math.BigDecimal
 
 /**
- * Represents the SI unit **joule per kelvin mole (J/(K·mol))**.
- *
- * This unit measures **molar heat capacity**, i.e., the amount of heat required
- * to raise the temperature of one mole of a substance by one kelvin.
- * It is defined as the [Quotient] of [Joule] (energy) divided by the [Product] of
- * [Kelvin] (temperature) and [Mole] (amount of substance).
- *
- * Example usages include:
- * - Determining the molar heat capacity of water (~75.3 J/(K·mol))
- * - Thermodynamic calculations in chemistry and materials science
- * - Analyzing energy changes per mole during temperature variations
- *
- * @see MolarHeatCapacity for the physical quantity represented by this unit.
- */
-typealias JoulePerKelvinMole = Quotient<Joule, Product<Kelvin, Mole>>
-
-/**
- * Creates a measure of **joules per kelvin-mole** (J/(K·mol)).
- *
- * This derived unit is used in thermodynamics to express energy,
- * heat capacity or entropy per unit temperature per amount of substance.
- *
- * Internally this returns a [Quotient] of:
- *  - a [Joule] (energy) with the specified [prefix]
- *  - divided by a [Product] of [Kelvin] (temperature)
- *    and [Mole] (amount of substance)
- *
- * @param prefix Metric prefix to apply to the joule unit.
- * Defaults to [Metric.BASE] (no prefix).
- *
- * @return A [Quotient] representing J/(K·mol).
- */
-@Suppress("FunctionNaming")
-internal fun JoulePerKelvinMole(prefix: Metric = Metric.BASE): Quotient<Joule, Product<Kelvin, Mole>> =
-    Quotient(
-        Joule(prefix),
-        Product(Kelvin(), Mole())
-    )
-
-/**
  * Represents the **molar heat capacity** of a substance.
  *
  * Molar heat capacity is the amount of heat required to raise the temperature
@@ -70,10 +30,56 @@ internal fun JoulePerKelvinMole(prefix: Metric = Metric.BASE): Quotient<Joule, P
 class MolarHeatCapacity(
     magnitude: BigDecimal,
     expression: JoulePerKelvinMole
-) : Measure<JoulePerKelvinMole, MolarHeatCapacity>(magnitude, expression, ::MolarHeatCapacity) {
+) : Measure<MolarHeatCapacity.JoulePerKelvinMole, MolarHeatCapacity>(
+    magnitude = magnitude,
+    expression = expression,
+    create = ::MolarHeatCapacity
+) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(
             magnitude,
             JoulePerKelvinMole(prefix)
         )
+
+    /**
+     * Represents the SI unit **joule per kelvin mole (J/(K·mol))**.
+     *
+     * This unit measures **molar heat capacity**, i.e., the amount of heat required
+     * to raise the temperature of one mole of a substance by one kelvin.
+     * It is defined as the [Quotient] of [Joule] (energy) divided by the [Product] of
+     * [Kelvin] (temperature) and [Mole] (amount of substance).
+     *
+     * Example usages include:
+     * - Determining the molar heat capacity of water (~75.3 J/(K·mol))
+     * - Thermodynamic calculations in chemistry and materials science
+     * - Analyzing energy changes per mole during temperature variations
+     *
+     * @see MolarHeatCapacity for the physical quantity represented by this unit.
+     */
+    typealias JoulePerKelvinMole = Quotient<Joule, Product<Kelvin, Mole>>
+
+    companion object {
+        /**
+         * Creates a measure of **joules per kelvin-mole** (J/(K·mol)).
+         *
+         * This derived unit is used in thermodynamics to express energy,
+         * heat capacity or entropy per unit temperature per amount of substance.
+         *
+         * Internally this returns a [Quotient] of:
+         *  - a [Joule] (energy) with the specified [prefix]
+         *  - divided by a [Product] of [Kelvin] (temperature)
+         *    and [Mole] (amount of substance)
+         *
+         * @param prefix Metric prefix to apply to the joule unit.
+         * Defaults to [Metric.BASE] (no prefix).
+         *
+         * @return A [Quotient] representing J/(K·mol).
+         */
+        @Suppress("FunctionNaming")
+        internal fun JoulePerKelvinMole(prefix: Metric = Metric.BASE): Quotient<Joule, Product<Kelvin, Mole>> =
+            Quotient(
+                Joule(prefix),
+                Product(Kelvin(), Mole())
+            )
+    }
 }

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/MolarMass.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/MolarMass.kt
@@ -8,40 +8,6 @@ import org.kisu.units.representation.Quotient
 import java.math.BigDecimal
 
 /**
- * Represents the SI unit **kilogram per mole (kg/mol)**.
- *
- * This unit measures **molar mass**, i.e., the mass of one mole of a substance.
- * It is defined as the [Quotient] of [Kilogram] (mass) divided by [Mole] (amount of substance).
- *
- * Example usages include:
- * - Determining the mass of one mole of water (~0.018 kg/mol)
- * - Stoichiometric calculations in chemical reactions
- * - Molecular and thermodynamic property analyses
- *
- * @see MolarMass for the physical quantity represented by this unit.
- */
-typealias KilogramPerMole = Quotient<Kilogram, Mole>
-
-/**
- * Creates a measure of **kilograms per mole** (kg/mol).
- *
- * This derived unit is used to express mass per amount of substance,
- * for example molar mass in chemistry.
- *
- * Internally this returns a [Quotient] of:
- *  - a [Kilogram] (mass) with the specified [prefix]
- *  - divided by a [Mole] (amount of substance)
- *
- * @param prefix Metric prefix to apply to the kilogram unit.
- * Defaults to [Metric.BASE] (no prefix).
- *
- * @return A [Quotient] representing kg/mol.
- */
-@Suppress("FunctionNaming")
-internal fun KilogramPerMole(prefix: Metric = Metric.BASE): Quotient<Kilogram, Mole> =
-    Quotient(Kilogram(prefix), Mole())
-
-/**
  * Represents the physical quantity of **molar mass**.
  *
  * Molar mass quantifies the **mass of one mole of a substance**.
@@ -62,7 +28,44 @@ internal fun KilogramPerMole(prefix: Metric = Metric.BASE): Quotient<Kilogram, M
 class MolarMass(
     magnitude: BigDecimal,
     expression: KilogramPerMole
-) : Measure<KilogramPerMole, MolarMass>(magnitude, expression, ::MolarMass) {
+) : Measure<MolarMass.KilogramPerMole, MolarMass>(magnitude, expression, ::MolarMass) {
+
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, KilogramPerMole(prefix))
+
+    /**
+     * Represents the SI unit **kilogram per mole (kg/mol)**.
+     *
+     * This unit measures **molar mass**, i.e., the mass of one mole of a substance.
+     * It is defined as the [Quotient] of [Kilogram] (mass) divided by [Mole] (amount of substance).
+     *
+     * Example usages include:
+     * - Determining the mass of one mole of water (~0.018 kg/mol)
+     * - Stoichiometric calculations in chemical reactions
+     * - Molecular and thermodynamic property analyses
+     *
+     * @see MolarMass for the physical quantity represented by this unit.
+     */
+    typealias KilogramPerMole = Quotient<Kilogram, Mole>
+
+    companion object {
+        /**
+         * Creates a measure of **kilograms per mole** (kg/mol).
+         *
+         * This derived unit is used to express mass per amount of substance,
+         * for example molar mass in chemistry.
+         *
+         * Internally this returns a [Quotient] of:
+         *  - a [Kilogram] (mass) with the specified [prefix]
+         *  - divided by a [Mole] (amount of substance)
+         *
+         * @param prefix Metric prefix to apply to the kilogram unit.
+         * Defaults to [Metric.BASE] (no prefix).
+         *
+         * @return A [Quotient] representing kg/mol.
+         */
+        @Suppress("FunctionNaming")
+        internal fun KilogramPerMole(prefix: Metric = Metric.BASE): Quotient<Kilogram, Mole> =
+            Quotient(Kilogram(prefix), Mole())
+    }
 }

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/MolarVolume.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/MolarVolume.kt
@@ -8,41 +8,6 @@ import org.kisu.units.special.CubicMetre
 import java.math.BigDecimal
 
 /**
- * Represents the SI unit **cubic metre per mole (m³/mol)**.
- *
- * This unit measures **molar volume**, i.e., the volume occupied by one mole
- * of a substance.
- * It is defined as the [Quotient] of [CubicMetre] (volume) divided by [Mole] (amount of substance).
- *
- * Example usages include:
- * - Calculating the volume of gases using the ideal gas law
- * - Determining molar volumes of liquids and solids
- * - Chemical and thermodynamic calculations
- *
- * @see MolarVolume for the physical quantity represented by this unit.
- */
-typealias CubicMetrePerMole = Quotient<CubicMetre, Mole>
-
-/**
- * Creates a measure of **cubic metres per mole** (m³/mol).
- *
- * This derived unit is used to express volume per amount of substance,
- * for example molar volume in chemistry and physics.
- *
- * Internally this returns a [Quotient] of:
- *  - a [CubicMetre] (volume) with the specified [prefix]
- *  - divided by a [Mole] (amount of substance)
- *
- * @param prefix Metric prefix to apply to the cubic metre unit.
- * Defaults to [Metric.BASE] (no prefix).
- *
- * @return A [Quotient] representing m³/mol.
- */
-@Suppress("FunctionNaming")
-internal fun CubicMetrePerMole(prefix: Metric = Metric.BASE): Quotient<CubicMetre, Mole> =
-    Quotient(CubicMetre(prefix), Mole())
-
-/**
  * Represents the physical quantity of **molar volume**.
  *
  * Molar volume quantifies the **volume occupied by one mole of a substance**.
@@ -63,7 +28,45 @@ internal fun CubicMetrePerMole(prefix: Metric = Metric.BASE): Quotient<CubicMetr
 class MolarVolume(
     magnitude: BigDecimal,
     expression: CubicMetrePerMole
-) : Measure<CubicMetrePerMole, MolarVolume>(magnitude, expression, ::MolarVolume) {
+) : Measure<MolarVolume.CubicMetrePerMole, MolarVolume>(magnitude, expression, ::MolarVolume) {
+
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, CubicMetrePerMole(prefix))
+
+    /**
+     * Represents the SI unit **cubic metre per mole (m³/mol)**.
+     *
+     * This unit measures **molar volume**, i.e., the volume occupied by one mole
+     * of a substance.
+     * It is defined as the [Quotient] of [CubicMetre] (volume) divided by [Mole] (amount of substance).
+     *
+     * Example usages include:
+     * - Calculating the volume of gases using the ideal gas law
+     * - Determining molar volumes of liquids and solids
+     * - Chemical and thermodynamic calculations
+     *
+     * @see MolarVolume for the physical quantity represented by this unit.
+     */
+    typealias CubicMetrePerMole = Quotient<CubicMetre, Mole>
+
+    companion object {
+        /**
+         * Creates a measure of **cubic metres per mole** (m³/mol).
+         *
+         * This derived unit is used to express volume per amount of substance,
+         * for example molar volume in chemistry and physics.
+         *
+         * Internally this returns a [Quotient] of:
+         *  - a [CubicMetre] (volume) with the specified [prefix]
+         *  - divided by a [Mole] (amount of substance)
+         *
+         * @param prefix Metric prefix to apply to the cubic metre unit.
+         * Defaults to [Metric.BASE] (no prefix).
+         *
+         * @return A [Quotient] representing m³/mol.
+         */
+        @Suppress("FunctionNaming")
+        internal fun CubicMetrePerMole(prefix: Metric = Metric.BASE): Quotient<CubicMetre, Mole> =
+            Quotient(CubicMetre(prefix), Mole())
+    }
 }

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/Molarity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/Molarity.kt
@@ -8,42 +8,6 @@ import org.kisu.units.special.CubicMetre
 import java.math.BigDecimal
 
 /**
- * Represents the SI unit **mole per cubic metre (mol/m³)**.
- *
- * This unit measures **molarity**, i.e., the number of moles of a substance
- * present in a unit volume of solution.
- * It is defined as the [Quotient] of [Mole] (amount of substance) divided by [CubicMetre] (volume).
- *
- * Example usages include:
- * - Expressing the concentration of a solution in chemistry and chemical engineering
- * - Calculating reactant availability in volumetric reactions
- * - Thermodynamic and solution property analyses
- *
- * @see Molarity for the physical quantity represented by this unit.
- */
-typealias MolePerCubicMetre = Quotient<Mole, CubicMetre>
-
-/**
- * Creates a measure of **moles per cubic metre** (mol/m³).
- *
- * This derived unit is widely used in chemistry and physics
- * to express the amount of substance per unit volume
- * (molar concentration in SI base units).
- *
- * Internally this returns a [Quotient] of:
- *  - a [Mole] (amount of substance) with the specified [prefix]
- *  - divided by a [CubicMetre] (volume)
- *
- * @param prefix Metric prefix to apply to the mole unit.
- * Defaults to [Metric.BASE] (no prefix).
- *
- * @return A [Quotient] representing mol/m³.
- */
-@Suppress("FunctionNaming")
-internal fun MolePerCubicMetre(prefix: Metric = Metric.BASE): Quotient<Mole, CubicMetre> =
-    Quotient(Mole(prefix), CubicMetre())
-
-/**
  * Represents the **molarity** (also called **molar concentration**) of a solution.
  *
  * Molarity is the number of moles of solute present in one cubic metre of solution.
@@ -63,7 +27,46 @@ internal fun MolePerCubicMetre(prefix: Metric = Metric.BASE): Quotient<Mole, Cub
 class Molarity(
     magnitude: BigDecimal,
     expression: MolePerCubicMetre
-) : Measure<MolePerCubicMetre, Molarity>(magnitude, expression, ::Molarity) {
+) : Measure<Molarity.MolePerCubicMetre, Molarity>(magnitude, expression, ::Molarity) {
+
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, MolePerCubicMetre(prefix))
+
+    /**
+     * Represents the SI unit **mole per cubic metre (mol/m³)**.
+     *
+     * This unit measures **molarity**, i.e., the number of moles of a substance
+     * present in a unit volume of solution.
+     * It is defined as the [Quotient] of [Mole] (amount of substance) divided by [CubicMetre] (volume).
+     *
+     * Example usages include:
+     * - Expressing the concentration of a solution in chemistry and chemical engineering
+     * - Calculating reactant availability in volumetric reactions
+     * - Thermodynamic and solution property analyses
+     *
+     * @see Molarity for the physical quantity represented by this unit.
+     */
+    typealias MolePerCubicMetre = Quotient<Mole, CubicMetre>
+
+    companion object {
+        /**
+         * Creates a measure of **moles per cubic metre** (mol/m³).
+         *
+         * This derived unit is widely used in chemistry and physics
+         * to express the amount of substance per unit volume
+         * (molar concentration in SI base units).
+         *
+         * Internally this returns a [Quotient] of:
+         *  - a [Mole] (amount of substance) with the specified [prefix]
+         *  - divided by a [CubicMetre] (volume)
+         *
+         * @param prefix Metric prefix to apply to the mole unit.
+         * Defaults to [Metric.BASE] (no prefix).
+         *
+         * @return A [Quotient] representing mol/m³.
+         */
+        @Suppress("FunctionNaming")
+        internal fun MolePerCubicMetre(prefix: Metric = Metric.BASE): Quotient<Mole, CubicMetre> =
+            Quotient(Mole(prefix), CubicMetre())
+    }
 }

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/ElectricChargeDensity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/ElectricChargeDensity.kt
@@ -8,21 +8,6 @@ import org.kisu.units.special.CubicMetre
 import java.math.BigDecimal
 
 /**
- * Represents the SI unit **coulomb per cubic metre (C/m³)**.
- *
- * This unit measures **electric charge density**, i.e., the amount of electric
- * charge per unit volume.
- * It is defined as the [Quotient] of [Coulomb] (electric charge) and [CubicMetre] (volume).
- *
- * Example usages include:
- * - Describing the distribution of charge in a volume
- * - Calculating electric fields from volumetric charge distributions
- *
- * @see ElectricChargeDensity for the physical quantity represented by this unit.
- */
-typealias CoulombPerCubicMetre = Quotient<Coulomb, CubicMetre>
-
-/**
  * Represents **electric charge density** in the SI system.
  *
  * Electric charge density measures the amount of electric charge distributed
@@ -43,7 +28,27 @@ typealias CoulombPerCubicMetre = Quotient<Coulomb, CubicMetre>
 class ElectricChargeDensity(
     magnitude: BigDecimal,
     expression: CoulombPerCubicMetre
-) : Measure<CoulombPerCubicMetre, ElectricChargeDensity>(magnitude, expression, ::ElectricChargeDensity) {
+) : Measure<ElectricChargeDensity.CoulombPerCubicMetre, ElectricChargeDensity>(
+    magnitude = magnitude,
+    expression = expression,
+    create = ::ElectricChargeDensity
+) {
+
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Coulomb(prefix), CubicMetre()))
+
+    /**
+     * Represents the SI unit **coulomb per cubic metre (C/m³)**.
+     *
+     * This unit measures **electric charge density**, i.e., the amount of electric
+     * charge per unit volume.
+     * It is defined as the [Quotient] of [Coulomb] (electric charge) and [CubicMetre] (volume).
+     *
+     * Example usages include:
+     * - Describing the distribution of charge in a volume
+     * - Calculating electric fields from volumetric charge distributions
+     *
+     * @see ElectricChargeDensity for the physical quantity represented by this unit.
+     */
+    typealias CoulombPerCubicMetre = Quotient<Coulomb, CubicMetre>
 }

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/ElectricConductivity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/ElectricConductivity.kt
@@ -8,21 +8,6 @@ import org.kisu.units.special.Siemens
 import java.math.BigDecimal
 
 /**
- * Represents the SI unit **siemens per metre (S/m)**.
- *
- * This unit measures **electric conductivity**, i.e., the ability of a material
- * to conduct electric current per unit length.
- * It is defined as the [Quotient] of [Siemens] (conductance) and [Metre] (length).
- *
- * Example usages include:
- * - Characterizing the conductivity of metals, semiconductors, and electrolytes
- * - Electrical engineering and materials science calculations
- *
- * @see ElectricConductivity for the physical quantity represented by this unit.
- */
-typealias SiemensPerMetre = Quotient<Siemens, Metre>
-
-/**
  * Represents **electric conductivity** in the SI system.
  *
  * Electric conductivity quantifies a material's ability to conduct an electric current.
@@ -45,7 +30,27 @@ typealias SiemensPerMetre = Quotient<Siemens, Metre>
 class ElectricConductivity(
     magnitude: BigDecimal,
     expression: SiemensPerMetre
-) : Measure<SiemensPerMetre, ElectricConductivity>(magnitude, expression, ::ElectricConductivity) {
+) : Measure<ElectricConductivity.SiemensPerMetre, ElectricConductivity>(
+    magnitude = magnitude,
+    expression = expression,
+    create = ::ElectricConductivity
+) {
+
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Siemens(prefix), Metre()))
+
+    /**
+     * Represents the SI unit **siemens per metre (S/m)**.
+     *
+     * This unit measures **electric conductivity**, i.e., the ability of a material
+     * to conduct electric current per unit length.
+     * It is defined as the [Quotient] of [Siemens] (conductance) and [Metre] (length).
+     *
+     * Example usages include:
+     * - Characterizing the conductivity of metals, semiconductors, and electrolytes
+     * - Electrical engineering and materials science calculations
+     *
+     * @see ElectricConductivity for the physical quantity represented by this unit.
+     */
+    typealias SiemensPerMetre = Quotient<Siemens, Metre>
 }

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/ElectricCurrentDensity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/ElectricCurrentDensity.kt
@@ -8,21 +8,6 @@ import org.kisu.units.special.SquareMetre
 import java.math.BigDecimal
 
 /**
- * Represents the SI unit **ampere per square metre (A/m²)**.
- *
- * This unit measures **electric current density**, i.e., the amount of electric
- * current flowing per unit cross-sectional area.
- * It is defined as the [Quotient] of [Ampere] (electric current) and [SquareMetre] (area).
- *
- * Example usages include:
- * - Describing current flow in conductors
- * - Modeling electromagnetics and circuit behavior
- *
- * @see ElectricCurrentDensity for the physical quantity represented by this unit.
- */
-typealias AmperePerSquareMetre = Quotient<Ampere, SquareMetre>
-
-/**
  * Represents **electric current density** in the SI system.
  *
  * Electric current density describes the amount of electric current flowing per unit
@@ -48,7 +33,27 @@ typealias AmperePerSquareMetre = Quotient<Ampere, SquareMetre>
 class ElectricCurrentDensity(
     magnitude: BigDecimal,
     expression: AmperePerSquareMetre
-) : Measure<AmperePerSquareMetre, ElectricCurrentDensity>(magnitude, expression, ::ElectricCurrentDensity) {
+) : Measure<ElectricCurrentDensity.AmperePerSquareMetre, ElectricCurrentDensity>(
+    magnitude = magnitude,
+    expression = expression,
+    create = ::ElectricCurrentDensity
+) {
+
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Ampere(prefix), SquareMetre()))
+
+    /**
+     * Represents the SI unit **ampere per square metre (A/m²)**.
+     *
+     * This unit measures **electric current density**, i.e., the amount of electric
+     * current flowing per unit cross-sectional area.
+     * It is defined as the [Quotient] of [Ampere] (electric current) and [SquareMetre] (area).
+     *
+     * Example usages include:
+     * - Describing current flow in conductors
+     * - Modeling electromagnetics and circuit behavior
+     *
+     * @see ElectricCurrentDensity for the physical quantity represented by this unit.
+     */
+    typealias AmperePerSquareMetre = Quotient<Ampere, SquareMetre>
 }

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/ElectricDisplacementField.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/ElectricDisplacementField.kt
@@ -8,21 +8,6 @@ import org.kisu.units.special.SquareMetre
 import java.math.BigDecimal
 
 /**
- * Represents the SI unit **coulomb per square metre (C/m²)**.
- *
- * This unit measures **electric displacement field**, i.e., the electric charge
- * per unit area on a surface.
- * It is defined as the [Quotient] of [Coulomb] (electric charge) and [SquareMetre] (area).
- *
- * Example usages include:
- * - Calculating surface charge distributions
- * - Modeling dielectric materials and capacitors
- *
- * @see ElectricDisplacementField for the physical quantity represented by this unit.
- */
-typealias CoulombPerSquareMetre = Quotient<Coulomb, SquareMetre>
-
-/**
  * Represents the **electric displacement field (D)** in SI units.
  *
  * The electric displacement field describes how electric fields interact with
@@ -47,7 +32,27 @@ typealias CoulombPerSquareMetre = Quotient<Coulomb, SquareMetre>
 class ElectricDisplacementField(
     magnitude: BigDecimal,
     expression: CoulombPerSquareMetre
-) : Measure<CoulombPerSquareMetre, ElectricDisplacementField>(magnitude, expression, ::ElectricDisplacementField) {
+) : Measure<ElectricDisplacementField.CoulombPerSquareMetre, ElectricDisplacementField>(
+    magnitude = magnitude,
+    expression = expression,
+    create = ::ElectricDisplacementField
+) {
+
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Coulomb(prefix), SquareMetre()))
+
+    /**
+     * Represents the SI unit **coulomb per square metre (C/m²)**.
+     *
+     * This unit measures **electric displacement field**, i.e., the electric charge
+     * per unit area on a surface.
+     * It is defined as the [Quotient] of [Coulomb] (electric charge) and [SquareMetre] (area).
+     *
+     * Example usages include:
+     * - Calculating surface charge distributions
+     * - Modeling dielectric materials and capacitors
+     *
+     * @see ElectricDisplacementField for the physical quantity represented by this unit.
+     */
+    typealias CoulombPerSquareMetre = Quotient<Coulomb, SquareMetre>
 }

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/ElectricFieldStrength.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/ElectricFieldStrength.kt
@@ -8,21 +8,6 @@ import org.kisu.units.special.Volt
 import java.math.BigDecimal
 
 /**
- * Represents the SI unit **volt per metre (V/m)**.
- *
- * This unit measures **electric field strength**, i.e., the force experienced by
- * a unit positive charge per unit distance.
- * It is defined as the [Quotient] of [Volt] (electric potential) and [Metre] (distance).
- *
- * Example usages include:
- * - Calculating the intensity of electric fields
- * - Modeling forces on charges in electrostatics
- *
- * @see ElectricFieldStrength for the physical quantity represented by this unit.
- */
-typealias VoltPerMetre = Quotient<Volt, Metre>
-
-/**
  * Represents **electric field strength** in the SI system.
  *
  * Electric field strength describes the force experienced by a unit positive charge
@@ -52,7 +37,27 @@ typealias VoltPerMetre = Quotient<Volt, Metre>
 class ElectricFieldStrength(
     magnitude: BigDecimal,
     expression: VoltPerMetre
-) : Measure<VoltPerMetre, ElectricFieldStrength>(magnitude, expression, ::ElectricFieldStrength) {
+) : Measure<ElectricFieldStrength.VoltPerMetre, ElectricFieldStrength>(
+    magnitude = magnitude,
+    expression = expression,
+    create = ::ElectricFieldStrength
+) {
+
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Volt(prefix), Metre()))
+
+    /**
+     * Represents the SI unit **volt per metre (V/m)**.
+     *
+     * This unit measures **electric field strength**, i.e., the force experienced by
+     * a unit positive charge per unit distance.
+     * It is defined as the [Quotient] of [Volt] (electric potential) and [Metre] (distance).
+     *
+     * Example usages include:
+     * - Calculating the intensity of electric fields
+     * - Modeling forces on charges in electrostatics
+     *
+     * @see ElectricFieldStrength for the physical quantity represented by this unit.
+     */
+    typealias VoltPerMetre = Quotient<Volt, Metre>
 }

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/ElectronMobility.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/ElectronMobility.kt
@@ -10,22 +10,6 @@ import org.kisu.units.special.Volt
 import java.math.BigDecimal
 
 /**
- * Represents the SI unit **square metre per volt-second (m²/(V·s))**.
- *
- * This unit measures **electron mobility**, i.e., how quickly an electron
- * can move through a material under the influence of an electric field.
- * It is defined as the [Quotient] of [SquareMetre] (area) and the [Product] of
- * [Volt] (electric potential) and [Second] (time).
- *
- * Example usages include:
- * - Characterizing charge carrier mobility in semiconductors
- * - Modeling conductivity and drift velocity in materials
- *
- * @see ElectronMobility for the physical quantity represented by this unit.
- */
-typealias SquareMetrePerVoltSecond = Quotient<SquareMetre, Product<Volt, Second>>
-
-/**
  * Represents **electron mobility** (μ), which describes how quickly an electron
  * can move through a material under the influence of an electric field.
  *
@@ -42,7 +26,12 @@ typealias SquareMetrePerVoltSecond = Quotient<SquareMetre, Product<Volt, Second>
 class ElectronMobility(
     magnitude: BigDecimal,
     expression: SquareMetrePerVoltSecond
-) : Measure<SquareMetrePerVoltSecond, ElectronMobility>(magnitude, expression, ::ElectronMobility) {
+) : Measure<ElectronMobility.SquareMetrePerVoltSecond, ElectronMobility>(
+    magnitude = magnitude,
+    expression = expression,
+    create = ::ElectronMobility
+) {
+
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(
             magnitude,
@@ -51,4 +40,20 @@ class ElectronMobility(
                 Product(Volt(), Second())
             )
         )
+
+    /**
+     * Represents the SI unit **square metre per volt-second (m²/(V·s))**.
+     *
+     * This unit measures **electron mobility**, i.e., how quickly an electron
+     * can move through a material under the influence of an electric field.
+     * It is defined as the [Quotient] of [SquareMetre] (area) and the [Product] of
+     * [Volt] (electric potential) and [Second] (time).
+     *
+     * Example usages include:
+     * - Characterizing charge carrier mobility in semiconductors
+     * - Modeling conductivity and drift velocity in materials
+     *
+     * @see ElectronMobility for the physical quantity represented by this unit.
+     */
+    typealias SquareMetrePerVoltSecond = Quotient<SquareMetre, Product<Volt, Second>>
 }

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/Exposure.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/Exposure.kt
@@ -8,21 +8,6 @@ import org.kisu.units.special.Coulomb
 import java.math.BigDecimal
 
 /**
- * Represents the SI unit **coulomb per kilogram (C/kg)**.
- *
- * This unit measures **radiation exposure**, i.e., the amount of ionizing
- * radiation in terms of the electric charge produced per unit mass of air.
- * It is defined as the [Quotient] of [Coulomb] (electric charge) and [Kilogram] (mass).
- *
- * Example usages include:
- * - Measuring ionizing radiation in air
- * - Radiation protection and dosimetry calculations
- *
- * @see Exposure for the physical quantity represented by this unit.
- */
-typealias CoulombPerKilogram = Quotient<Coulomb, Kilogram>
-
-/**
  * Represents **radiation exposure** (X), which quantifies the amount of ionizing
  * radiation in terms of the electric charge produced per unit mass of air.
  *
@@ -40,7 +25,23 @@ typealias CoulombPerKilogram = Quotient<Coulomb, Kilogram>
 class Exposure(
     magnitude: BigDecimal,
     expression: CoulombPerKilogram
-) : Measure<CoulombPerKilogram, Exposure>(magnitude, expression, ::Exposure) {
+) : Measure<Exposure.CoulombPerKilogram, Exposure>(magnitude, expression, ::Exposure) {
+
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Coulomb(prefix), Kilogram()))
+
+    /**
+     * Represents the SI unit **coulomb per kilogram (C/kg)**.
+     *
+     * This unit measures **radiation exposure**, i.e., the amount of ionizing
+     * radiation in terms of the electric charge produced per unit mass of air.
+     * It is defined as the [Quotient] of [Coulomb] (electric charge) and [Kilogram] (mass).
+     *
+     * Example usages include:
+     * - Measuring ionizing radiation in air
+     * - Radiation protection and dosimetry calculations
+     *
+     * @see Exposure for the physical quantity represented by this unit.
+     */
+    typealias CoulombPerKilogram = Quotient<Coulomb, Kilogram>
 }

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/LinearChargeDensity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/LinearChargeDensity.kt
@@ -8,21 +8,6 @@ import org.kisu.units.special.Coulomb
 import java.math.BigDecimal
 
 /**
- * Represents the SI unit **coulomb per metre (C/m)**.
- *
- * This unit measures **linear charge density**, i.e., the amount of electric
- * charge distributed per unit length.
- * It is defined as the [Quotient] of [Coulomb] (electric charge) and [Metre] (length).
- *
- * Example usages include:
- * - Describing charge along wires, filaments, or rods
- * - Calculating electric fields from line charge distributions
- *
- * @see LinearChargeDensity for the physical quantity represented by this unit.
- */
-typealias CoulombPerMetre = Quotient<Coulomb, Metre>
-
-/**
  * Represents **linear charge density** (λ), which is the amount of electric charge
  * distributed per unit length of a line.
  *
@@ -40,7 +25,27 @@ typealias CoulombPerMetre = Quotient<Coulomb, Metre>
 class LinearChargeDensity(
     magnitude: BigDecimal,
     expression: CoulombPerMetre
-) : Measure<CoulombPerMetre, LinearChargeDensity>(magnitude, expression, ::LinearChargeDensity) {
+) : Measure<LinearChargeDensity.CoulombPerMetre, LinearChargeDensity>(
+    magnitude = magnitude,
+    expression = expression,
+    create = ::LinearChargeDensity
+) {
+
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Coulomb(prefix), Metre()))
+
+    /**
+     * Represents the SI unit **coulomb per metre (C/m)**.
+     *
+     * This unit measures **linear charge density**, i.e., the amount of electric
+     * charge distributed per unit length.
+     * It is defined as the [Quotient] of [Coulomb] (electric charge) and [Metre] (length).
+     *
+     * Example usages include:
+     * - Describing charge along wires, filaments, or rods
+     * - Calculating electric fields from line charge distributions
+     *
+     * @see LinearChargeDensity for the physical quantity represented by this unit.
+     */
+    typealias CoulombPerMetre = Quotient<Coulomb, Metre>
 }

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/MagneticDipoleMoment.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/MagneticDipoleMoment.kt
@@ -8,21 +8,6 @@ import org.kisu.units.special.Tesla
 import java.math.BigDecimal
 
 /**
- * Represents the SI unit **joule per tesla (J/T)**.
- *
- * This unit measures **magnetic dipole moment**, i.e., the torque a magnetic
- * source experiences in a magnetic field per unit field strength.
- * It is defined as the [Quotient] of [Joule] (energy) and [Tesla] (magnetic flux density).
- *
- * Example usages include:
- * - Quantifying the magnetic dipole moment of magnets or current loops
- * - Modeling interactions of magnetic moments with external magnetic fields
- *
- * @see MagneticDipoleMoment for the physical quantity represented by this unit.
- */
-typealias JoulePerTesla = Quotient<Joule, Tesla>
-
-/**
  * Represents the **magnetic dipole moment** (m), a vector quantity that measures
  * the strength and orientation of a magnetic source.
  *
@@ -39,7 +24,27 @@ typealias JoulePerTesla = Quotient<Joule, Tesla>
 class MagneticDipoleMoment(
     magnitude: BigDecimal,
     expression: JoulePerTesla
-) : Measure<JoulePerTesla, MagneticDipoleMoment>(magnitude, expression, ::MagneticDipoleMoment) {
+) : Measure<MagneticDipoleMoment.JoulePerTesla, MagneticDipoleMoment>(
+    magnitude = magnitude,
+    expression = expression,
+    create = ::MagneticDipoleMoment
+) {
+
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Joule(prefix), Tesla()))
+
+    /**
+     * Represents the SI unit **joule per tesla (J/T)**.
+     *
+     * This unit measures **magnetic dipole moment**, i.e., the torque a magnetic
+     * source experiences in a magnetic field per unit field strength.
+     * It is defined as the [Quotient] of [Joule] (energy) and [Tesla] (magnetic flux density).
+     *
+     * Example usages include:
+     * - Quantifying the magnetic dipole moment of magnets or current loops
+     * - Modeling interactions of magnetic moments with external magnetic fields
+     *
+     * @see MagneticDipoleMoment for the physical quantity represented by this unit.
+     */
+    typealias JoulePerTesla = Quotient<Joule, Tesla>
 }

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/MagneticMoment.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/MagneticMoment.kt
@@ -8,21 +8,6 @@ import org.kisu.units.special.Weber
 import java.math.BigDecimal
 
 /**
- * Represents the SI unit **weber metre (Wb·m)**.
- *
- * This unit measures **magnetic moment**, i.e., the strength of a magnet or
- * current loop in terms of magnetic flux times length.
- * It is defined as the [Product] of [Weber] (magnetic flux) and [Metre] (length).
- *
- * Example usages include:
- * - Calculating magnetic moments of coils or permanent magnets
- * - Modeling torque and energy in magnetic systems
- *
- * @see MagneticMoment for the physical quantity represented by this unit.
- */
-typealias WeberMetre = Product<Weber, Metre>
-
-/**
  * Represents the **magnetic moment** (μ), a vector quantity that measures
  * the strength and orientation of a magnet or current loop.
  *
@@ -44,7 +29,23 @@ typealias WeberMetre = Product<Weber, Metre>
 class MagneticMoment(
     magnitude: BigDecimal,
     expression: WeberMetre
-) : Measure<WeberMetre, MagneticMoment>(magnitude, expression, ::MagneticMoment) {
+) : Measure<MagneticMoment.WeberMetre, MagneticMoment>(magnitude, expression, ::MagneticMoment) {
+
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Product(Weber(prefix), Metre()))
+
+    /**
+     * Represents the SI unit **weber metre (Wb·m)**.
+     *
+     * This unit measures **magnetic moment**, i.e., the strength of a magnet or
+     * current loop in terms of magnetic flux times length.
+     * It is defined as the [Product] of [Weber] (magnetic flux) and [Metre] (length).
+     *
+     * Example usages include:
+     * - Calculating magnetic moments of coils or permanent magnets
+     * - Modeling torque and energy in magnetic systems
+     *
+     * @see MagneticMoment for the physical quantity represented by this unit.
+     */
+    typealias WeberMetre = Product<Weber, Metre>
 }

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/MagneticPermittivity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/MagneticPermittivity.kt
@@ -8,21 +8,6 @@ import org.kisu.units.special.Henry
 import java.math.BigDecimal
 
 /**
- * Represents the SI unit **henry per metre (H/m)**.
- *
- * This unit measures **magnetic permeability**, i.e., the ability of a material
- * to support the formation of a magnetic field.
- * It is defined as the [Quotient] of [Henry] (inductance) and [Metre] (length).
- *
- * Example usages include:
- * - Characterizing magnetic properties of materials
- * - Designing inductors, transformers, and magnetic circuits
- *
- * @see MagneticPermittivity for the physical quantity represented by this unit.
- */
-typealias HenryPerMetre = Quotient<Henry, Metre>
-
-/**
  * Represents **magnetic permeability** (μ), a measure of a material's ability
  * to support the formation of a magnetic field within itself.
  *
@@ -46,7 +31,27 @@ typealias HenryPerMetre = Quotient<Henry, Metre>
 class MagneticPermittivity(
     magnitude: BigDecimal,
     expression: HenryPerMetre
-) : Measure<HenryPerMetre, MagneticPermittivity>(magnitude, expression, ::MagneticPermittivity) {
+) : Measure<MagneticPermittivity.HenryPerMetre, MagneticPermittivity>(
+    magnitude = magnitude,
+    expression = expression,
+    create = ::MagneticPermittivity
+) {
+
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Henry(prefix), Metre()))
+
+    /**
+     * Represents the SI unit **henry per metre (H/m)**.
+     *
+     * This unit measures **magnetic permeability**, i.e., the ability of a material
+     * to support the formation of a magnetic field.
+     * It is defined as the [Quotient] of [Henry] (inductance) and [Metre] (length).
+     *
+     * Example usages include:
+     * - Characterizing magnetic properties of materials
+     * - Designing inductors, transformers, and magnetic circuits
+     *
+     * @see MagneticPermittivity for the physical quantity represented by this unit.
+     */
+    typealias HenryPerMetre = Quotient<Henry, Metre>
 }

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/MagneticRigidity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/MagneticRigidity.kt
@@ -8,21 +8,6 @@ import org.kisu.units.special.Tesla
 import java.math.BigDecimal
 
 /**
- * Represents the SI unit **tesla metre (T·m)**.
- *
- * This unit measures **magnetic rigidity**, i.e., the resistance of a charged
- * particle to deflection by a magnetic field.
- * It is defined as the [Product] of [Tesla] (magnetic flux density) and [Metre] (length).
- *
- * Example usages include:
- * - Calculating particle trajectory bending in magnetic fields
- * - Designing magnetic spectrometers and accelerator beamlines
- *
- * @see MagneticRigidity for the physical quantity represented by this unit.
- */
-typealias TeslaMetre = Product<Tesla, Metre>
-
-/**
  * Represents **magnetic rigidity**, which quantifies the resistance of a charged
  * particle to deflection by a magnetic field.
  *
@@ -47,7 +32,23 @@ typealias TeslaMetre = Product<Tesla, Metre>
 class MagneticRigidity(
     magnitude: BigDecimal,
     expression: TeslaMetre
-) : Measure<TeslaMetre, MagneticRigidity>(magnitude, expression, ::MagneticRigidity) {
+) : Measure<MagneticRigidity.TeslaMetre, MagneticRigidity>(magnitude, expression, ::MagneticRigidity) {
+
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Product(Tesla(prefix), Metre()))
+
+    /**
+     * Represents the SI unit **tesla metre (T·m)**.
+     *
+     * This unit measures **magnetic rigidity**, i.e., the resistance of a charged
+     * particle to deflection by a magnetic field.
+     * It is defined as the [Product] of [Tesla] (magnetic flux density) and [Metre] (length).
+     *
+     * Example usages include:
+     * - Calculating particle trajectory bending in magnetic fields
+     * - Designing magnetic spectrometers and accelerator beamlines
+     *
+     * @see MagneticRigidity for the physical quantity represented by this unit.
+     */
+    typealias TeslaMetre = Product<Tesla, Metre>
 }

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/MagneticSusceptibility.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/MagneticSusceptibility.kt
@@ -8,21 +8,6 @@ import org.kisu.units.special.Henry
 import java.math.BigDecimal
 
 /**
- * Represents the SI unit **metre per henry (m/H)**.
- *
- * This unit measures **magnetic susceptibility**, i.e., the degree to which
- * a material can be magnetized in response to an applied magnetic field.
- * It is defined as the [Quotient] of [Metre] (length) and [Henry] (inductance).
- *
- * Example usages include:
- * - Characterizing diamagnetic, paramagnetic, or ferromagnetic materials
- * - Modeling magnetic response in materials and circuits
- *
- * @see MagneticSusceptibility for the physical quantity represented by this unit.
- */
-typealias MetrePerHenry = Quotient<Metre, Henry>
-
-/**
  * Represents **magnetic susceptibility** (χ), a dimensionless quantity that
  * describes how much a material becomes magnetized in response to an applied
  * magnetic field.
@@ -44,7 +29,27 @@ typealias MetrePerHenry = Quotient<Metre, Henry>
 class MagneticSusceptibility(
     magnitude: BigDecimal,
     expression: MetrePerHenry
-) : Measure<MetrePerHenry, MagneticSusceptibility>(magnitude, expression, ::MagneticSusceptibility) {
+) : Measure<MagneticSusceptibility.MetrePerHenry, MagneticSusceptibility>(
+    magnitude = magnitude,
+    expression = expression,
+    create = ::MagneticSusceptibility
+) {
+
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Metre(prefix), Henry()))
+
+    /**
+     * Represents the SI unit **metre per henry (m/H)**.
+     *
+     * This unit measures **magnetic susceptibility**, i.e., the degree to which
+     * a material can be magnetized in response to an applied magnetic field.
+     * It is defined as the [Quotient] of [Metre] (length) and [Henry] (inductance).
+     *
+     * Example usages include:
+     * - Characterizing diamagnetic, paramagnetic, or ferromagnetic materials
+     * - Modeling magnetic response in materials and circuits
+     *
+     * @see MagneticSusceptibility for the physical quantity represented by this unit.
+     */
+    typealias MetrePerHenry = Quotient<Metre, Henry>
 }

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/MagneticVectorPotential.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/MagneticVectorPotential.kt
@@ -8,21 +8,6 @@ import org.kisu.units.special.Weber
 import java.math.BigDecimal
 
 /**
- * Represents the SI unit **weber per metre (Wb/m)**.
- *
- * This unit measures **magnetic vector potential**, i.e., the magnetic flux
- * per unit length.
- * It is defined as the [Quotient] of [Weber] (magnetic flux) and [Metre] (length).
- *
- * Example usages include:
- * - Calculating magnetic fields from vector potentials
- * - Modeling inductors and electromagnetic devices
- *
- * @see MagneticVectorPotential for the physical quantity represented by this unit.
- */
-typealias WeberPerMetre = Quotient<Weber, Metre>
-
-/**
  * Represents the **magnetic vector potential** (A), a vector field used in
  * electromagnetism to describe the magnetic field in terms of a potential.
  *
@@ -47,7 +32,27 @@ typealias WeberPerMetre = Quotient<Weber, Metre>
 class MagneticVectorPotential(
     magnitude: BigDecimal,
     expression: WeberPerMetre
-) : Measure<WeberPerMetre, MagneticVectorPotential>(magnitude, expression, ::MagneticVectorPotential) {
+) : Measure<MagneticVectorPotential.WeberPerMetre, MagneticVectorPotential>(
+    magnitude = magnitude,
+    expression = expression,
+    create = ::MagneticVectorPotential
+) {
+
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Weber(prefix), Metre()))
+
+    /**
+     * Represents the SI unit **weber per metre (Wb/m)**.
+     *
+     * This unit measures **magnetic vector potential**, i.e., the magnetic flux
+     * per unit length.
+     * It is defined as the [Quotient] of [Weber] (magnetic flux) and [Metre] (length).
+     *
+     * Example usages include:
+     * - Calculating magnetic fields from vector potentials
+     * - Modeling inductors and electromagnetic devices
+     *
+     * @see MagneticVectorPotential for the physical quantity represented by this unit.
+     */
+    typealias WeberPerMetre = Quotient<Weber, Metre>
 }

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/Magnetization.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/Magnetization.kt
@@ -8,21 +8,6 @@ import org.kisu.units.representation.Quotient
 import java.math.BigDecimal
 
 /**
- * Represents the SI unit **ampere per metre (A/m)**.
- *
- * This unit measures **magnetization**, i.e., the magnetic moment per unit
- * length of a material.
- * It is defined as the [Quotient] of [Ampere] (electric current) and [Metre] (length).
- *
- * Example usages include:
- * - Characterizing the magnetic response of materials
- * - Designing magnetic circuits and devices
- *
- * @see Magnetization for the physical quantity represented by this unit.
- */
-typealias AmperePerMetre = Quotient<Ampere, Metre>
-
-/**
  * Represents **magnetization** (M), a measure of the magnetic moment per unit
  * volume of a material.
  *
@@ -46,7 +31,23 @@ typealias AmperePerMetre = Quotient<Ampere, Metre>
 class Magnetization(
     magnitude: BigDecimal,
     expression: AmperePerMetre
-) : Measure<AmperePerMetre, Magnetization>(magnitude, expression, ::Magnetization) {
+) : Measure<Magnetization.AmperePerMetre, Magnetization>(magnitude, expression, ::Magnetization) {
+
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Ampere(prefix), Metre()))
+
+    /**
+     * Represents the SI unit **ampere per metre (A/m)**.
+     *
+     * This unit measures **magnetization**, i.e., the magnetic moment per unit
+     * length of a material.
+     * It is defined as the [Quotient] of [Ampere] (electric current) and [Metre] (length).
+     *
+     * Example usages include:
+     * - Characterizing the magnetic response of materials
+     * - Designing magnetic circuits and devices
+     *
+     * @see Magnetization for the physical quantity represented by this unit.
+     */
+    typealias AmperePerMetre = Quotient<Ampere, Metre>
 }

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/MagnetomotiveForce.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/MagnetomotiveForce.kt
@@ -8,21 +8,6 @@ import org.kisu.units.special.Radian
 import java.math.BigDecimal
 
 /**
- * Represents the SI unit **ampere-radian (A·rad)**.
- *
- * This unit measures **magnetomotive force**, i.e., the driving force that
- * produces magnetic flux in a magnetic circuit.
- * It is defined as the [Product] of [Ampere] (electric current) and [Radian] (angle).
- *
- * Example usages include:
- * - Calculating magnetomotive force in coils and solenoids
- * - Designing magnetic circuits and electromagnets
- *
- * @see MagnetomotiveForce for the physical quantity represented by this unit.
- */
-typealias AmpereRadian = Product<Ampere, Radian>
-
-/**
  * Represents **magnetomotive force** (MMF, 𝓕), which drives magnetic flux
  * through a magnetic circuit, analogous to electromotive force in electrical circuits.
  *
@@ -49,7 +34,23 @@ typealias AmpereRadian = Product<Ampere, Radian>
 class MagnetomotiveForce(
     magnitude: BigDecimal,
     expression: AmpereRadian
-) : Measure<AmpereRadian, MagnetomotiveForce>(magnitude, expression, ::MagnetomotiveForce) {
+) : Measure<MagnetomotiveForce.AmpereRadian, MagnetomotiveForce>(magnitude, expression, ::MagnetomotiveForce) {
+
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Product(Ampere(prefix), Radian()))
+
+    /**
+     * Represents the SI unit **ampere-radian (A·rad)**.
+     *
+     * This unit measures **magnetomotive force**, i.e., the driving force that
+     * produces magnetic flux in a magnetic circuit.
+     * It is defined as the [Product] of [Ampere] (electric current) and [Radian] (angle).
+     *
+     * Example usages include:
+     * - Calculating magnetomotive force in coils and solenoids
+     * - Designing magnetic circuits and electromagnets
+     *
+     * @see MagnetomotiveForce for the physical quantity represented by this unit.
+     */
+    typealias AmpereRadian = Product<Ampere, Radian>
 }

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/Permittivity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/Permittivity.kt
@@ -8,21 +8,6 @@ import org.kisu.units.special.Farad
 import java.math.BigDecimal
 
 /**
- * Represents the SI unit **farad per metre (F/m)**.
- *
- * This unit measures **electric permittivity**, i.e., the ability of a material
- * to permit the formation of an electric field within it.
- * It is defined as the [Quotient] of [Farad] (capacitance) and [Metre] (length).
- *
- * Example usages include:
- * - Characterizing dielectric materials
- * - Designing capacitors and insulating systems
- *
- * @see Permittivity for the physical quantity represented by this unit.
- */
-typealias FaradPerMetre = Quotient<Farad, Metre>
-
-/**
  * Represents **electric permittivity** (ε), a measure of a material's ability
  * to permit the formation of an electric field within it.
  *
@@ -45,7 +30,23 @@ typealias FaradPerMetre = Quotient<Farad, Metre>
 class Permittivity(
     magnitude: BigDecimal,
     expression: FaradPerMetre
-) : Measure<FaradPerMetre, Permittivity>(magnitude, expression, ::Permittivity) {
+) : Measure<Permittivity.FaradPerMetre, Permittivity>(magnitude, expression, ::Permittivity) {
+
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Farad(prefix), Metre()))
+
+    /**
+     * Represents the SI unit **farad per metre (F/m)**.
+     *
+     * This unit measures **electric permittivity**, i.e., the ability of a material
+     * to permit the formation of an electric field within it.
+     * It is defined as the [Quotient] of [Farad] (capacitance) and [Metre] (length).
+     *
+     * Example usages include:
+     * - Characterizing dielectric materials
+     * - Designing capacitors and insulating systems
+     *
+     * @see Permittivity for the physical quantity represented by this unit.
+     */
+    typealias FaradPerMetre = Quotient<Farad, Metre>
 }

--- a/lib/src/main/kotlin/org/kisu/units/electromagnetic/Resistivity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/electromagnetic/Resistivity.kt
@@ -8,21 +8,6 @@ import org.kisu.units.special.Ohm
 import java.math.BigDecimal
 
 /**
- * Represents the SI unit **ohm metre (Ω·m)**.
- *
- * This unit measures **electrical resistivity**, i.e., the intrinsic property
- * of a material that opposes the flow of electric current.
- * It is defined as the [Product] of [Ohm] (electrical resistance) and [Metre] (length).
- *
- * Example usages include:
- * - Characterizing conductors and insulators
- * - Designing electrical circuits and materials
- *
- * @see Resistivity for the physical quantity represented by this unit.
- */
-typealias OhmMetre = Product<Ohm, Metre>
-
-/**
  * Represents **electrical resistivity** (ρ), a measure of how strongly a material
  * opposes the flow of electric current.
  *
@@ -49,7 +34,23 @@ typealias OhmMetre = Product<Ohm, Metre>
 class Resistivity(
     magnitude: BigDecimal,
     expression: OhmMetre
-) : Measure<OhmMetre, Resistivity>(magnitude, expression, ::Resistivity) {
+) : Measure<Resistivity.OhmMetre, Resistivity>(magnitude, expression, ::Resistivity) {
+
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Product(Ohm(prefix), Metre()))
+
+    /**
+     * Represents the SI unit **ohm metre (Ω·m)**.
+     *
+     * This unit measures **electrical resistivity**, i.e., the intrinsic property
+     * of a material that opposes the flow of electric current.
+     * It is defined as the [Product] of [Ohm] (electrical resistance) and [Metre] (length).
+     *
+     * Example usages include:
+     * - Characterizing conductors and insulators
+     * - Designing electrical circuits and materials
+     *
+     * @see Resistivity for the physical quantity represented by this unit.
+     */
+    typealias OhmMetre = Product<Ohm, Metre>
 }

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/FrequencyDrift.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/FrequencyDrift.kt
@@ -7,8 +7,6 @@ import org.kisu.units.representation.Quotient
 import org.kisu.units.special.Hertz
 import java.math.BigDecimal
 
-typealias HertzPerSecond = Quotient<Hertz, Second>
-
 /**
  * Represents the physical quantity of **frequency drift**, the rate of change of frequency over time.
  *
@@ -29,7 +27,23 @@ typealias HertzPerSecond = Quotient<Hertz, Second>
 class FrequencyDrift internal constructor(
     magnitude: BigDecimal,
     expression: HertzPerSecond
-) : Measure<HertzPerSecond, FrequencyDrift>(magnitude, expression, ::FrequencyDrift) {
+) : Measure<FrequencyDrift.HertzPerSecond, FrequencyDrift>(magnitude, expression, ::FrequencyDrift) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Hertz(prefix), Second()))
+
+    /**
+     * Represents the SI unit **hertz per second (Hz/s)**.
+     *
+     * This unit is used to measure **frequency change rate** or **frequency acceleration**,
+     * i.e., how quickly the frequency of an oscillation or signal changes over time.
+     * It is defined as the [Quotient] of [Hertz] (frequency) divided by [Second] (time).
+     *
+     * Example usages include:
+     * - Characterising the rate of change of frequency in mechanical or electrical oscillators
+     * - Describing chirp signals or frequency sweeps in signal processing
+     * - Measuring acceleration of rotational speed in machinery
+     *
+     * @see FrequencyDrift
+     */
+    typealias HertzPerSecond = Quotient<Hertz, Second>
 }

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/VolumetricFlow.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/VolumetricFlow.kt
@@ -7,8 +7,6 @@ import org.kisu.units.representation.Quotient
 import org.kisu.units.special.CubicMetre
 import java.math.BigDecimal
 
-typealias CubicMetrePerSecond = Quotient<CubicMetre, Second>
-
 /**
  * Represents the physical quantity of **volumetric flow**, the rate of volume change over time.
  *
@@ -29,7 +27,23 @@ typealias CubicMetrePerSecond = Quotient<CubicMetre, Second>
 class VolumetricFlow internal constructor(
     magnitude: BigDecimal,
     expression: CubicMetrePerSecond
-) : Measure<CubicMetrePerSecond, VolumetricFlow>(magnitude, expression, ::VolumetricFlow) {
+) : Measure<VolumetricFlow.CubicMetrePerSecond, VolumetricFlow>(magnitude, expression, ::VolumetricFlow) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(CubicMetre(prefix), Second()))
+
+    /**
+     * Represents the SI unit **cubic metre per second (m³/s)**.
+     *
+     * This unit is used to measure **volumetric flow rate**,
+     * i.e., the volume of a fluid passing through a given surface per unit time.
+     * It is defined as the [Quotient] of [CubicMetre] (volume) divided by [Second] (time).
+     *
+     * Example usages include:
+     * - Measuring river discharge or water flow in hydrology
+     * - Specifying pump or ventilation system capacities
+     * - Quantifying fluid transport in engineering processes
+     *
+     * @see VolumetricFlow
+     */
+    typealias CubicMetrePerSecond = Quotient<CubicMetre, Second>
 }

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/Yank.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/Yank.kt
@@ -9,9 +9,6 @@ import org.kisu.units.representation.Product
 import org.kisu.units.representation.Quotient
 import java.math.BigDecimal
 
-typealias KilogramMetre = Product<Kilogram, Metre>
-typealias KilogramMetreSecondThird = Quotient<KilogramMetre, SecondCubed>
-
 /**
  * Represents the physical quantity of **yank**, the rate of change of force over time.
  *
@@ -33,7 +30,7 @@ typealias KilogramMetreSecondThird = Quotient<KilogramMetre, SecondCubed>
 class Yank internal constructor(
     magnitude: BigDecimal,
     expression: KilogramMetreSecondThird
-) : Measure<KilogramMetreSecondThird, Yank>(magnitude, expression, ::Yank) {
+) : Measure<Yank.KilogramMetreSecondThird, Yank>(magnitude, expression, ::Yank) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(
             magnitude,
@@ -42,4 +39,36 @@ class Yank internal constructor(
                 SecondCubed()
             )
         )
+
+    /**
+     * Represents the SI unit **kilogram metre (kg·m)**.
+     *
+     * This composite unit combines **mass and distance**.
+     * It is defined as the [Product] of [Kilogram] (mass) and [Metre] (length).
+     *
+     * Although not an SI derived unit with a specific name, it appears in
+     * intermediate steps of physics and engineering calculations.
+     *
+     * Example usages include:
+     * - Expressing moments or torque before dividing by time or angle
+     * - Serving as an intermediate quantity in mechanics or material science
+     *
+     * @see KilogramMetreSecondThird
+     */
+    typealias KilogramMetre = Product<Kilogram, Metre>
+
+    /**
+     * Represents the SI unit **kilogram metre per second cubed (kg·m/s³)**.
+     *
+     * This unit is used to measure **mass flow rate of acceleration or power per velocity**
+     * (an uncommon but valid derived unit in mechanics and engineering).
+     * It is defined as the [Quotient] of [KilogramMetre] (mass × length) divided by [SecondCubed] (time³).
+     *
+     * Example usages include:
+     * - Appearing in intermediate formulas for dynamic systems
+     * - Describing certain transport phenomena or rate-of-change quantities in physics
+     *
+     * @see Yank
+     */
+    typealias KilogramMetreSecondThird = Quotient<KilogramMetre, SecondCubed>
 }

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Acceleration.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Acceleration.kt
@@ -7,8 +7,6 @@ import org.kisu.units.representation.Quotient
 import org.kisu.units.special.Radian
 import java.math.BigDecimal
 
-typealias RadianPerSecondSquared = Quotient<Radian, SecondSquared>
-
 /**
  * Represents the physical quantity of **angular acceleration**.
  *
@@ -29,7 +27,23 @@ typealias RadianPerSecondSquared = Quotient<Radian, SecondSquared>
 class Acceleration(
     magnitude: BigDecimal,
     expression: RadianPerSecondSquared
-) : Measure<RadianPerSecondSquared, Acceleration>(magnitude, expression, ::Acceleration) {
+) : Measure<Acceleration.RadianPerSecondSquared, Acceleration>(magnitude, expression, ::Acceleration) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Radian(prefix), SecondSquared()))
+
+    /**
+     * Represents the SI unit **radian per second squared (rad/s²)**.
+     *
+     * This unit is used to measure **angular acceleration**,
+     * i.e., the rate of change of angular velocity with respect to time.
+     * It is defined as the [Quotient] of [Radian] (angle) divided by [SecondSquared] (time²).
+     *
+     * Example usages include:
+     * - Determining the angular acceleration of rotating machinery
+     * - Analysing the dynamics of wheels, gears, or turbines
+     * - Calculating rotational kinematics in physics and engineering
+     *
+     * @see Acceleration
+     */
+    typealias RadianPerSecondSquared = Quotient<Radian, SecondSquared>
 }

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Crackle.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Crackle.kt
@@ -7,8 +7,6 @@ import org.kisu.units.representation.Quotient
 import org.kisu.units.special.Radian
 import java.math.BigDecimal
 
-typealias RadianPerSecondFifth = Quotient<Radian, SecondQuintic>
-
 /**
  * Represents the physical quantity of **angular crackle**, the fifth derivative of angular position with respect to
  * time.
@@ -30,7 +28,24 @@ typealias RadianPerSecondFifth = Quotient<Radian, SecondQuintic>
 class Crackle internal constructor(
     magnitude: BigDecimal,
     expression: RadianPerSecondFifth
-) : Measure<RadianPerSecondFifth, Crackle>(magnitude, expression, ::Crackle) {
+) : Measure<Crackle.RadianPerSecondFifth, Crackle>(magnitude, expression, ::Crackle) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Radian(prefix), SecondQuintic()))
+
+    /**
+     * Represents the SI unit **radian per second to the fifth power (rad/s⁵)**.
+     *
+     * This unit is used to measure the **fifth time derivative of angular position**,
+     * sometimes called **angular crackle** or higher-order angular rate change,
+     * i.e., how rapidly angular jerk or snap itself changes over time.
+     * It is defined as the [Quotient] of [Radian] (angle) divided by [SecondQuintic] (time⁵).
+     *
+     * Example usages include:
+     * - High-order rotational motion analysis in robotics or aerospace
+     * - Modelling vibration or oscillatory systems with complex dynamics
+     * - Advanced control systems requiring precise higher-order derivatives
+     *
+     * @see Crackle
+     */
+    typealias RadianPerSecondFifth = Quotient<Radian, SecondQuintic>
 }

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Jerk.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Jerk.kt
@@ -7,8 +7,6 @@ import org.kisu.units.representation.Quotient
 import org.kisu.units.special.Radian
 import java.math.BigDecimal
 
-typealias RadianPerSecondCubed = Quotient<Radian, SecondCubed>
-
 /**
  * Represents the physical quantity of **angular jerk**, the third derivative of angular position with respect to time.
  *
@@ -29,7 +27,24 @@ typealias RadianPerSecondCubed = Quotient<Radian, SecondCubed>
 class Jerk(
     magnitude: BigDecimal,
     expression: RadianPerSecondCubed
-) : Measure<RadianPerSecondCubed, Jerk>(magnitude, expression, ::Jerk) {
+) : Measure<Jerk.RadianPerSecondCubed, Jerk>(magnitude, expression, ::Jerk) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Radian(prefix), SecondCubed()))
+
+    /**
+     * Represents the SI unit **radian per second cubed (rad/s³)**.
+     *
+     * This unit is used to measure the **third time derivative of angular position**,
+     * commonly called **angular jerk** or **angular jolt**,
+     * i.e., the rate of change of angular acceleration with respect to time.
+     * It is defined as the [Quotient] of [Radian] (angle) divided by [SecondCubed] (time³).
+     *
+     * Example usages include:
+     * - Analysing rapid changes in angular acceleration in robotics or aerospace
+     * - Modelling rotational dynamics of precision mechanisms
+     * - Designing control systems where higher-order derivatives of motion are relevant
+     *
+     * @see Jerk
+     */
+    typealias RadianPerSecondCubed = Quotient<Radian, SecondCubed>
 }

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Pop.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Pop.kt
@@ -7,8 +7,6 @@ import org.kisu.units.representation.Quotient
 import org.kisu.units.special.Radian
 import java.math.BigDecimal
 
-typealias RadianPerSecondSixth = Quotient<Radian, SecondSextic>
-
 /**
  * Represents the physical quantity of **angular pop**, the sixth derivative of angular position with respect to time.
  *
@@ -29,7 +27,24 @@ typealias RadianPerSecondSixth = Quotient<Radian, SecondSextic>
 class Pop internal constructor(
     magnitude: BigDecimal,
     expression: RadianPerSecondSixth
-) : Measure<RadianPerSecondSixth, Pop>(magnitude, expression, ::Pop) {
+) : Measure<Pop.RadianPerSecondSixth, Pop>(magnitude, expression, ::Pop) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Radian(prefix), SecondSextic()))
+
+    /**
+     * Represents the SI unit **radian per second to the sixth power (rad/s⁶)**.
+     *
+     * This unit is used to measure the **sixth time derivative of angular position**,
+     * sometimes referred to as **angular pop** or higher-order angular rate change,
+     * i.e., how rapidly the fifth derivative of angular position changes over time.
+     * It is defined as the [Quotient] of [Radian] (angle) divided by [SecondSextic] (time⁶).
+     *
+     * Example usages include:
+     * - Very high-order rotational motion analysis in robotics, aerospace, or vibration studies
+     * - Advanced modelling of oscillatory systems with complex dynamics
+     * - Control algorithms that incorporate higher-order derivatives for precision movement
+     *
+     * @see Pop
+     */
+    typealias RadianPerSecondSixth = Quotient<Radian, SecondSextic>
 }

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Snap.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Snap.kt
@@ -7,8 +7,6 @@ import org.kisu.units.representation.Quotient
 import org.kisu.units.special.Radian
 import java.math.BigDecimal
 
-typealias RadianPerSecondFourth = Quotient<Radian, SecondQuartic>
-
 /**
  * Represents the physical quantity of **angular snap**, the fourth derivative of angular position with respect to time.
  *
@@ -29,7 +27,24 @@ typealias RadianPerSecondFourth = Quotient<Radian, SecondQuartic>
 class Snap(
     magnitude: BigDecimal,
     expression: RadianPerSecondFourth
-) : Measure<RadianPerSecondFourth, Snap>(magnitude, expression, ::Snap) {
+) : Measure<Snap.RadianPerSecondFourth, Snap>(magnitude, expression, ::Snap) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Radian(prefix), SecondQuartic()))
+
+    /**
+     * Represents the SI unit **radian per second to the fourth power (rad/s⁴)**.
+     *
+     * This unit is used to measure the **fourth time derivative of angular position**,
+     * sometimes called **angular snap**,
+     * i.e., the rate of change of angular jerk with respect to time.
+     * It is defined as the [Quotient] of [Radian] (angle) divided by [SecondQuartic] (time⁴).
+     *
+     * Example usages include:
+     * - Analysing high-order rotational motion in robotics or aerospace
+     * - Modelling dynamic systems where angular acceleration changes rapidly
+     * - Designing precision control systems requiring higher-order derivatives
+     *
+     * @see Snap
+     */
+    typealias RadianPerSecondFourth = Quotient<Radian, SecondQuartic>
 }

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Velocity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Velocity.kt
@@ -7,8 +7,6 @@ import org.kisu.units.representation.Quotient
 import org.kisu.units.special.Radian
 import java.math.BigDecimal
 
-typealias RadianPerSecond = Quotient<Radian, Second>
-
 /**
  * Represents the physical quantity of **angular velocity**.
  *
@@ -29,7 +27,23 @@ typealias RadianPerSecond = Quotient<Radian, Second>
 class Velocity(
     magnitude: BigDecimal,
     expression: RadianPerSecond
-) : Measure<RadianPerSecond, Velocity>(magnitude, expression, ::Velocity) {
+) : Measure<Velocity.RadianPerSecond, Velocity>(magnitude, expression, ::Velocity) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Radian(prefix), Second()))
+
+    /**
+     * Represents the SI unit **radian per second (rad/s)**.
+     *
+     * This unit is used to measure **angular velocity**,
+     * i.e., the rate of change of angular position with respect to time.
+     * It is defined as the [Quotient] of [Radian] (angle) divided by [Second] (time).
+     *
+     * Example usages include:
+     * - Measuring rotational speed of wheels, turbines, or motors
+     * - Describing the angular velocity of planets or satellites
+     * - Analysing the motion of rotating machinery in physics and engineering
+     *
+     * @see Velocity
+     */
+    typealias RadianPerSecond = Quotient<Radian, Second>
 }

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Acceleration.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Acceleration.kt
@@ -7,8 +7,6 @@ import org.kisu.units.base.SecondSquared
 import org.kisu.units.representation.Quotient
 import java.math.BigDecimal
 
-typealias MetrePerSecondSquared = Quotient<Metre, SecondSquared>
-
 /**
  * Represents the physical quantity of **acceleration**.
  *
@@ -29,7 +27,23 @@ typealias MetrePerSecondSquared = Quotient<Metre, SecondSquared>
 class Acceleration(
     magnitude: BigDecimal,
     expression: MetrePerSecondSquared
-) : Measure<MetrePerSecondSquared, Acceleration>(magnitude, expression, ::Acceleration) {
+) : Measure<Acceleration.MetrePerSecondSquared, Acceleration>(magnitude, expression, ::Acceleration) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Metre(prefix), SecondSquared()))
+
+    /**
+     * Represents the SI unit **metre per second squared (m/s²)**.
+     *
+     * This unit is used to measure **linear acceleration**,
+     * i.e., the rate of change of velocity with respect to time.
+     * It is defined as the [Quotient] of [Metre] (length) divided by [SecondSquared] (time²).
+     *
+     * Example usages include:
+     * - Describing the acceleration of vehicles, projectiles, or objects in free fall
+     * - Calculating forces in Newtonian mechanics using [Newton] = kg·m/s²
+     * - Analysing motion in physics and engineering contexts
+     *
+     * @see Acceleration
+     */
+    typealias MetrePerSecondSquared = Quotient<Metre, SecondSquared>
 }

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Crackle.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Crackle.kt
@@ -7,8 +7,6 @@ import org.kisu.units.base.SecondQuintic
 import org.kisu.units.representation.Quotient
 import java.math.BigDecimal
 
-typealias MetrePerSecondFifth = Quotient<Metre, SecondQuintic>
-
 /**
  * Represents the physical quantity of **crackle**, the fifth derivative of position with respect to time.
  *
@@ -29,7 +27,24 @@ typealias MetrePerSecondFifth = Quotient<Metre, SecondQuintic>
 class Crackle internal constructor(
     magnitude: BigDecimal,
     expression: MetrePerSecondFifth
-) : Measure<MetrePerSecondFifth, Crackle>(magnitude, expression, ::Crackle) {
+) : Measure<Crackle.MetrePerSecondFifth, Crackle>(magnitude, expression, ::Crackle) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Metre(prefix), SecondQuintic()))
+
+    /**
+     * Represents the SI unit **metre per second to the fifth power (m/s⁵)**.
+     *
+     * This unit is used to measure the **fifth time derivative of position**,
+     * sometimes referred to as **fifth-order linear rate change**,
+     * i.e., how rapidly the fourth derivative of displacement changes over time.
+     * It is defined as the [Quotient] of [Metre] (length) divided by [SecondQuintic] (time⁵).
+     *
+     * Example usages include:
+     * - Advanced dynamics simulations in physics or engineering
+     * - Modelling high-order motion derivatives in vibration analysis
+     * - Control systems requiring extremely precise motion prediction
+     *
+     * @see Crackle
+     */
+    typealias MetrePerSecondFifth = Quotient<Metre, SecondQuintic>
 }

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Jerk.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Jerk.kt
@@ -7,8 +7,6 @@ import org.kisu.units.base.SecondCubed
 import org.kisu.units.representation.Quotient
 import java.math.BigDecimal
 
-typealias MetrePerSecondCubed = Quotient<Metre, SecondCubed>
-
 /**
  * Represents the physical quantity of **jerk**, the third derivative of position with respect to time.
  *
@@ -29,7 +27,24 @@ typealias MetrePerSecondCubed = Quotient<Metre, SecondCubed>
 class Jerk(
     magnitude: BigDecimal,
     expression: MetrePerSecondCubed
-) : Measure<MetrePerSecondCubed, Jerk>(magnitude, expression, ::Jerk) {
+) : Measure<Jerk.MetrePerSecondCubed, Jerk>(magnitude, expression, ::Jerk) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Metre(prefix), SecondCubed()))
+
+    /**
+     * Represents the SI unit **metre per second cubed (m/s³)**.
+     *
+     * This unit is used to measure the **third time derivative of position**,
+     * commonly called **jerk** in linear motion,
+     * i.e., the rate of change of acceleration with respect to time.
+     * It is defined as the [Quotient] of [Metre] (length) divided by [SecondCubed] (time³).
+     *
+     * Example usages include:
+     * - Analysing rapid changes in acceleration in vehicles or machinery
+     * - Designing smooth motion profiles in robotics or automation
+     * - Studying vibrations or dynamic response in mechanical systems
+     *
+     * @see Jerk
+     */
+    typealias MetrePerSecondCubed = Quotient<Metre, SecondCubed>
 }

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Pop.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Pop.kt
@@ -7,8 +7,6 @@ import org.kisu.units.base.SecondSextic
 import org.kisu.units.representation.Quotient
 import java.math.BigDecimal
 
-typealias MetrePerSecondSixth = Quotient<Metre, SecondSextic>
-
 /**
  * Represents the physical quantity of **pop**, the sixth derivative of position with respect to time.
  *
@@ -29,7 +27,23 @@ typealias MetrePerSecondSixth = Quotient<Metre, SecondSextic>
 class Pop internal constructor(
     magnitude: BigDecimal,
     expression: MetrePerSecondSixth
-) : Measure<MetrePerSecondSixth, Pop>(magnitude, expression, ::Pop) {
+) : Measure<Pop.MetrePerSecondSixth, Pop>(magnitude, expression, ::Pop) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Metre(prefix), SecondSextic()))
+
+    /**
+     * Represents the SI unit **metre per second to the sixth power (m/s⁶)**.
+     *
+     * This unit is used to measure the **sixth time derivative of position**,
+     * i.e., how rapidly the fifth derivative of displacement changes over time.
+     * It is defined as the [Quotient] of [Metre] (length) divided by [SecondSextic] (time⁶).
+     *
+     * Example usages include:
+     * - Very high-order motion analysis in physics or engineering simulations
+     * - Advanced vibration studies or precision control systems
+     * - Modelling complex dynamic systems requiring higher-order derivatives
+     *
+     * @see Pop
+     */
+    typealias MetrePerSecondSixth = Quotient<Metre, SecondSextic>
 }

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Snap.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Snap.kt
@@ -7,8 +7,6 @@ import org.kisu.units.base.SecondQuartic
 import org.kisu.units.representation.Quotient
 import java.math.BigDecimal
 
-typealias MetrePerSecondFourth = Quotient<Metre, SecondQuartic>
-
 /**
  * Represents the physical quantity of **snap**, the fourth derivative of position with respect to time.
  *
@@ -29,7 +27,24 @@ typealias MetrePerSecondFourth = Quotient<Metre, SecondQuartic>
 class Snap(
     magnitude: BigDecimal,
     expression: MetrePerSecondFourth
-) : Measure<MetrePerSecondFourth, Snap>(magnitude, expression, ::Snap) {
+) : Measure<Snap.MetrePerSecondFourth, Snap>(magnitude, expression, ::Snap) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Metre(prefix), SecondQuartic()))
+
+    /**
+     * Represents the SI unit **metre per second to the fourth power (m/s⁴)**.
+     *
+     * This unit is used to measure the **fourth time derivative of position**,
+     * commonly called **snap** in linear motion,
+     * i.e., the rate of change of jerk with respect to time.
+     * It is defined as the [Quotient] of [Metre] (length) divided by [SecondQuartic] (time⁴).
+     *
+     * Example usages include:
+     * - Analysing high-order motion in robotics or mechanical systems
+     * - Designing smooth motion profiles in automation or vehicle dynamics
+     * - Modelling dynamic systems with rapidly changing acceleration
+     *
+     * @see Snap
+     */
+    typealias MetrePerSecondFourth = Quotient<Metre, SecondQuartic>
 }

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Speed.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Speed.kt
@@ -7,8 +7,6 @@ import org.kisu.units.base.Second
 import org.kisu.units.representation.Quotient
 import java.math.BigDecimal
 
-typealias MetrePerSecond = Quotient<Metre, Second>
-
 /**
  * Represents the physical quantity of **speed** (velocity magnitude).
  *
@@ -25,7 +23,23 @@ typealias MetrePerSecond = Quotient<Metre, Second>
 class Speed(
     magnitude: BigDecimal,
     expression: MetrePerSecond
-) : Measure<MetrePerSecond, Speed>(magnitude, expression, ::Speed) {
+) : Measure<Speed.MetrePerSecond, Speed>(magnitude, expression, ::Speed) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Metre(prefix), Second()))
+
+    /**
+     * Represents the SI unit **metre per second (m/s)**.
+     *
+     * This unit is used to measure **linear velocity**,
+     * i.e., the rate of change of position with respect to time.
+     * It is defined as the [Quotient] of [Metre] (length) divided by [Second] (time).
+     *
+     * Example usages include:
+     * - Measuring the speed of vehicles, projectiles, or moving objects
+     * - Describing fluid flow rates in physics and engineering
+     * - Analysing motion in mechanics and kinematics
+     *
+     * @see Speed
+     */
+    typealias MetrePerSecond = Quotient<Metre, Second>
 }

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/AbsorbedDoseRate.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/AbsorbedDoseRate.kt
@@ -8,22 +8,6 @@ import org.kisu.units.special.Gray
 import java.math.BigDecimal
 
 /**
- * Unit of [AbsorbedDoseRate].
- *
- * Represents the unit of **absorbed dose rate**, i.e. the rate at which
- * ionizing radiation energy is absorbed per unit of mass over time.
- *
- * Measured in **gray per second (Gy/s)**, which is defined as:
- * ```
- * 1 Gy/s = 1 J·kg⁻¹·s⁻¹ = 1 m²·s⁻³
- * ```
- * where 1 gray (Gy) = 1 joule per kilogram.
- *
- * @see AbsorbedDoseRate
- */
-typealias GrayPerSecond = Quotient<Gray, Second>
-
-/**
  * Measure of absorbed dose rate expressed in [GrayPerSecond].
  *
  * Absorbed dose rate quantifies the **intensity of ionizing radiation** in terms of
@@ -48,7 +32,23 @@ typealias GrayPerSecond = Quotient<Gray, Second>
 class AbsorbedDoseRate(
     magnitude: BigDecimal,
     expression: GrayPerSecond
-) : Measure<GrayPerSecond, AbsorbedDoseRate>(magnitude, expression, ::AbsorbedDoseRate) {
+) : Measure<AbsorbedDoseRate.GrayPerSecond, AbsorbedDoseRate>(magnitude, expression, ::AbsorbedDoseRate) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Gray(prefix), Second()))
+
+    /**
+     * Unit of [AbsorbedDoseRate].
+     *
+     * Represents the unit of **absorbed dose rate**, i.e. the rate at which
+     * ionizing radiation energy is absorbed per unit of mass over time.
+     *
+     * Measured in **gray per second (Gy/s)**, which is defined as:
+     * ```
+     * 1 Gy/s = 1 J·kg⁻¹·s⁻¹ = 1 m²·s⁻³
+     * ```
+     * where 1 gray (Gy) = 1 joule per kilogram.
+     *
+     * @see AbsorbedDoseRate
+     */
+    typealias GrayPerSecond = Quotient<Gray, Second>
 }

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/Action.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/Action.kt
@@ -8,19 +8,6 @@ import org.kisu.units.special.Joule
 import java.math.BigDecimal
 
 /**
- * Unit of [Action].
- *
- * Represents the unit of **action**, i.e., the physical quantity measuring
- * energy multiplied by time.
- *
- * Symbol: `J·s`
- * SI: `m²·kg·s⁻¹`
- *
- * @see Action
- */
-typealias JouleSecond = Product<Joule, Second>
-
-/**
  * Measure of action expressed in [JouleSecond].
  *
  * Action quantifies the product of energy and the time over which it is applied.
@@ -39,7 +26,20 @@ typealias JouleSecond = Product<Joule, Second>
 class Action(
     magnitude: BigDecimal,
     expression: JouleSecond
-) : Measure<JouleSecond, Action>(magnitude, expression, ::Action) {
+) : Measure<Action.JouleSecond, Action>(magnitude, expression, ::Action) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Product(Joule(prefix), Second()))
+
+    /**
+     * Unit of [Action].
+     *
+     * Represents the unit of **action**, i.e., the physical quantity measuring
+     * energy multiplied by time.
+     *
+     * Symbol: `J·s`
+     * SI: `m²·kg·s⁻¹`
+     *
+     * @see Action
+     */
+    typealias JouleSecond = Product<Joule, Second>
 }

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/AngularMomentum.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/AngularMomentum.kt
@@ -9,19 +9,6 @@ import org.kisu.units.special.Newton
 import java.math.BigDecimal
 
 /**
- * Unit of [AngularMomentum].
- *
- * Represents the unit of **angular momentum**, i.e., the physical quantity measuring
- * rotational momentum of a body.
- *
- * Symbol: `N·m·s`
- * SI: `m²·kg·s⁻¹`
- *
- * @see AngularMomentum
- */
-typealias NewtonMeterSecond = Product<Newton, Product<Metre, Second>>
-
-/**
  * Measure of angular momentum expressed in [NewtonMeterSecond].
  *
  * Angular momentum quantifies the rotational motion of a body, combining
@@ -40,7 +27,20 @@ typealias NewtonMeterSecond = Product<Newton, Product<Metre, Second>>
 class AngularMomentum(
     magnitude: BigDecimal,
     expression: NewtonMeterSecond
-) : Measure<NewtonMeterSecond, AngularMomentum>(magnitude, expression, ::AngularMomentum) {
+) : Measure<AngularMomentum.NewtonMeterSecond, AngularMomentum>(magnitude, expression, ::AngularMomentum) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Product(Newton(prefix), Product(Metre(), Second())))
+
+    /**
+     * Unit of [AngularMomentum].
+     *
+     * Represents the unit of **angular momentum**, i.e., the physical quantity measuring
+     * rotational momentum of a body.
+     *
+     * Symbol: `N·m·s`
+     * SI: `m²·kg·s⁻¹`
+     *
+     * @see AngularMomentum
+     */
+    typealias NewtonMeterSecond = Product<Newton, Product<Metre, Second>>
 }

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/AreaDensity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/AreaDensity.kt
@@ -8,19 +8,6 @@ import org.kisu.units.special.SquareMetre
 import java.math.BigDecimal
 
 /**
- * Unit of [AreaDensity].
- *
- * Represents the unit of **area density**, i.e., the physical quantity measuring
- * mass per unit area.
- *
- * Symbol: `kg/m²`
- * SI: `kg·m⁻²`
- *
- * @see AreaDensity
- */
-typealias KilogramPerSquareMetre = Quotient<Kilogram, SquareMetre>
-
-/**
  * Measure of area density expressed in [KilogramPerSquareMetre].
  *
  * Area density quantifies the amount of mass distributed over a given area.
@@ -38,7 +25,20 @@ typealias KilogramPerSquareMetre = Quotient<Kilogram, SquareMetre>
 class AreaDensity(
     magnitude: BigDecimal,
     expression: KilogramPerSquareMetre
-) : Measure<KilogramPerSquareMetre, AreaDensity>(magnitude, expression, ::AreaDensity) {
+) : Measure<AreaDensity.KilogramPerSquareMetre, AreaDensity>(magnitude, expression, ::AreaDensity) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Kilogram(prefix to BigDecimal.ONE), SquareMetre()))
+
+    /**
+     * Unit of [AreaDensity].
+     *
+     * Represents the unit of **area density**, i.e., the physical quantity measuring
+     * mass per unit area.
+     *
+     * Symbol: `kg/m²`
+     * SI: `kg·m⁻²`
+     *
+     * @see AreaDensity
+     */
+    typealias KilogramPerSquareMetre = Quotient<Kilogram, SquareMetre>
 }

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/Density.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/Density.kt
@@ -8,19 +8,6 @@ import org.kisu.units.special.CubicMetre
 import java.math.BigDecimal
 
 /**
- * Unit of [Density].
- *
- * Represents the unit of **density**, i.e., the physical quantity measuring
- * mass per unit volume.
- *
- * Symbol: `kg/m³`
- * SI: `kg·m⁻³`
- *
- * @see Density
- */
-typealias KilogramPerCubicMetre = Quotient<Kilogram, CubicMetre>
-
-/**
  * Measure of density expressed in [KilogramPerCubicMetre].
  *
  * Density quantifies how much mass is contained in a given volume of a substance.
@@ -38,7 +25,20 @@ typealias KilogramPerCubicMetre = Quotient<Kilogram, CubicMetre>
 class Density(
     magnitude: BigDecimal,
     expression: KilogramPerCubicMetre
-) : Measure<KilogramPerCubicMetre, Density>(magnitude, expression, ::Density) {
+) : Measure<Density.KilogramPerCubicMetre, Density>(magnitude, expression, ::Density) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Kilogram(prefix to BigDecimal.ONE), CubicMetre()))
+
+    /**
+     * Unit of [Density].
+     *
+     * Represents the unit of **density**, i.e., the physical quantity measuring
+     * mass per unit volume.
+     *
+     * Symbol: `kg/m³`
+     * SI: `kg·m⁻³`
+     *
+     * @see Density
+     */
+    typealias KilogramPerCubicMetre = Quotient<Kilogram, CubicMetre>
 }

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/DynamicViscosity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/DynamicViscosity.kt
@@ -8,19 +8,6 @@ import org.kisu.units.special.Pascal
 import java.math.BigDecimal
 
 /**
- * Unit of [DynamicViscosity].
- *
- * Represents the unit of **dynamic viscosity**, i.e., the physical quantity measuring
- * a fluid's resistance to flow under an applied shear stress.
- *
- * Symbol: `Pa·s`
- * SI: `kg·m⁻¹·s⁻¹`
- *
- * @see DynamicViscosity
- */
-typealias PascalSecond = Product<Pascal, Second>
-
-/**
  * Measure of dynamic viscosity expressed in [PascalSecond].
  *
  * Dynamic viscosity quantifies a fluid's internal resistance to motion
@@ -39,7 +26,20 @@ typealias PascalSecond = Product<Pascal, Second>
 class DynamicViscosity(
     magnitude: BigDecimal,
     expression: PascalSecond
-) : Measure<PascalSecond, DynamicViscosity>(magnitude, expression, ::DynamicViscosity) {
+) : Measure<DynamicViscosity.PascalSecond, DynamicViscosity>(magnitude, expression, ::DynamicViscosity) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Product(Pascal(prefix), Second()))
+
+    /**
+     * Unit of [DynamicViscosity].
+     *
+     * Represents the unit of **dynamic viscosity**, i.e., the physical quantity measuring
+     * a fluid's resistance to flow under an applied shear stress.
+     *
+     * Symbol: `Pa·s`
+     * SI: `kg·m⁻¹·s⁻¹`
+     *
+     * @see DynamicViscosity
+     */
+    typealias PascalSecond = Product<Pascal, Second>
 }

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/EnergyDensity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/EnergyDensity.kt
@@ -8,19 +8,6 @@ import org.kisu.units.special.Joule
 import java.math.BigDecimal
 
 /**
- * Unit of [EnergyDensity].
- *
- * Represents the unit of **energy density**, i.e., the physical quantity measuring
- * energy per unit volume.
- *
- * Symbol: `J/m³`
- * SI: `kg·m⁻¹·s⁻²`
- *
- * @see EnergyDensity
- */
-typealias JoulePerCubicMetre = Quotient<Joule, CubicMetre>
-
-/**
  * Measure of energy density expressed in [JoulePerCubicMetre].
  *
  * Energy density quantifies how much energy is stored or contained in a given volume.
@@ -38,7 +25,20 @@ typealias JoulePerCubicMetre = Quotient<Joule, CubicMetre>
 class EnergyDensity(
     magnitude: BigDecimal,
     expression: JoulePerCubicMetre
-) : Measure<JoulePerCubicMetre, EnergyDensity>(magnitude, expression, ::EnergyDensity) {
+) : Measure<EnergyDensity.JoulePerCubicMetre, EnergyDensity>(magnitude, expression, ::EnergyDensity) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Joule(prefix), CubicMetre()))
+
+    /**
+     * Unit of [EnergyDensity].
+     *
+     * Represents the unit of **energy density**, i.e., the physical quantity measuring
+     * energy per unit volume.
+     *
+     * Symbol: `J/m³`
+     * SI: `kg·m⁻¹·s⁻²`
+     *
+     * @see EnergyDensity
+     */
+    typealias JoulePerCubicMetre = Quotient<Joule, CubicMetre>
 }

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/EnergyFluxDensity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/EnergyFluxDensity.kt
@@ -10,19 +10,6 @@ import org.kisu.units.special.SquareMetre
 import java.math.BigDecimal
 
 /**
- * Unit of [EnergyFluxDensity].
- *
- * Represents the unit of **energy flux density**, i.e., the physical quantity measuring
- * energy transferred per unit area per unit time.
- *
- * Symbol: `J/(m²·s)`
- * SI: `kg·s⁻³`
- *
- * @see EnergyFluxDensity
- */
-typealias JoulePerSquareMetreSecond = Quotient<Joule, Product<SquareMetre, Second>>
-
-/**
  * Measure of energy flux density expressed in [JoulePerSquareMetreSecond].
  *
  * Energy flux density quantifies the rate at which energy passes through a unit area.
@@ -40,7 +27,11 @@ typealias JoulePerSquareMetreSecond = Quotient<Joule, Product<SquareMetre, Secon
 class EnergyFluxDensity(
     magnitude: BigDecimal,
     expression: JoulePerSquareMetreSecond
-) : Measure<JoulePerSquareMetreSecond, EnergyFluxDensity>(magnitude, expression, ::EnergyFluxDensity) {
+) : Measure<EnergyFluxDensity.JoulePerSquareMetreSecond, EnergyFluxDensity>(
+    magnitude = magnitude,
+    expression = expression,
+    create = ::EnergyFluxDensity
+) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(
             magnitude,
@@ -49,4 +40,17 @@ class EnergyFluxDensity(
                 Product(SquareMetre(), Second())
             )
         )
+
+    /**
+     * Unit of [EnergyFluxDensity].
+     *
+     * Represents the unit of **energy flux density**, i.e., the physical quantity measuring
+     * energy transferred per unit area per unit time.
+     *
+     * Symbol: `J/(m²·s)`
+     * SI: `kg·s⁻³`
+     *
+     * @see EnergyFluxDensity
+     */
+    typealias JoulePerSquareMetreSecond = Quotient<Joule, Product<SquareMetre, Second>>
 }

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/FuelEfficiency.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/FuelEfficiency.kt
@@ -8,19 +8,6 @@ import org.kisu.units.special.CubicMetre
 import java.math.BigDecimal
 
 /**
- * Unit of [FuelEfficiency].
- *
- * Represents the unit of **fuel efficiency**, i.e., the physical quantity measuring
- * distance traveled per unit volume of fuel consumed.
- *
- * Symbol: `m/m³`
- * SI: `m⁻²`
- *
- * @see FuelEfficiency
- */
-typealias MetrePerCubicMetre = Quotient<Metre, CubicMetre>
-
-/**
  * Measure of fuel efficiency expressed in [MetrePerCubicMetre].
  *
  * Fuel efficiency quantifies how far a vehicle or engine can travel for a given
@@ -39,7 +26,20 @@ typealias MetrePerCubicMetre = Quotient<Metre, CubicMetre>
 class FuelEfficiency(
     magnitude: BigDecimal,
     expression: MetrePerCubicMetre
-) : Measure<MetrePerCubicMetre, FuelEfficiency>(magnitude, expression, ::FuelEfficiency) {
+) : Measure<FuelEfficiency.MetrePerCubicMetre, FuelEfficiency>(magnitude, expression, ::FuelEfficiency) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Metre(prefix), CubicMetre()))
+
+    /**
+     * Unit of [FuelEfficiency].
+     *
+     * Represents the unit of **fuel efficiency**, i.e., the physical quantity measuring
+     * distance traveled per unit volume of fuel consumed.
+     *
+     * Symbol: `m/m³`
+     * SI: `m⁻²`
+     *
+     * @see FuelEfficiency
+     */
+    typealias MetrePerCubicMetre = Quotient<Metre, CubicMetre>
 }

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/HeatFluxDensity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/HeatFluxDensity.kt
@@ -8,19 +8,6 @@ import org.kisu.units.special.Watt
 import java.math.BigDecimal
 
 /**
- * Unit of [HeatFluxDensity].
- *
- * Represents the unit of **heat flux density**, i.e., the physical quantity measuring
- * heat transfer per unit area per unit time.
- *
- * Symbol: `W/m²`
- * SI: `kg·s⁻³`
- *
- * @see HeatFluxDensity
- */
-typealias WattPerSquareMetre = Quotient<Watt, SquareMetre>
-
-/**
  * Measure of heat flux density expressed in [WattPerSquareMetre].
  *
  * Heat flux density quantifies the rate of heat transfer across a unit area.
@@ -38,7 +25,20 @@ typealias WattPerSquareMetre = Quotient<Watt, SquareMetre>
 class HeatFluxDensity(
     magnitude: BigDecimal,
     expression: WattPerSquareMetre
-) : Measure<WattPerSquareMetre, HeatFluxDensity>(magnitude, expression, ::HeatFluxDensity) {
+) : Measure<HeatFluxDensity.WattPerSquareMetre, HeatFluxDensity>(magnitude, expression, ::HeatFluxDensity) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Watt(prefix), SquareMetre()))
+
+    /**
+     * Unit of [HeatFluxDensity].
+     *
+     * Represents the unit of **heat flux density**, i.e., the physical quantity measuring
+     * heat transfer per unit area per unit time.
+     *
+     * Symbol: `W/m²`
+     * SI: `kg·s⁻³`
+     *
+     * @see HeatFluxDensity
+     */
+    typealias WattPerSquareMetre = Quotient<Watt, SquareMetre>
 }

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/KinematicViscosity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/KinematicViscosity.kt
@@ -8,19 +8,6 @@ import org.kisu.units.special.SquareMetre
 import java.math.BigDecimal
 
 /**
- * Unit of [KinematicViscosity].
- *
- * Represents the unit of **kinematic viscosity**, i.e., the physical quantity measuring
- * a fluid's resistance to flow relative to its density.
- *
- * Symbol: `m²/s`
- * SI: `m²·s⁻¹`
- *
- * @see KinematicViscosity
- */
-typealias SquareMetrePerSecond = Quotient<SquareMetre, Second>
-
-/**
  * Measure of kinematic viscosity expressed in [SquareMetrePerSecond].
  *
  * Kinematic viscosity quantifies the intrinsic resistance of a fluid to motion
@@ -39,7 +26,24 @@ typealias SquareMetrePerSecond = Quotient<SquareMetre, Second>
 class KinematicViscosity(
     magnitude: BigDecimal,
     expression: SquareMetrePerSecond
-) : Measure<SquareMetrePerSecond, KinematicViscosity>(magnitude, expression, ::KinematicViscosity) {
+) : Measure<KinematicViscosity.SquareMetrePerSecond, KinematicViscosity>(
+    magnitude = magnitude,
+    expression = expression,
+    create = ::KinematicViscosity
+) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(SquareMetre(prefix), Second()))
+
+    /**
+     * Unit of [KinematicViscosity].
+     *
+     * Represents the unit of **kinematic viscosity**, i.e., the physical quantity measuring
+     * a fluid's resistance to flow relative to its density.
+     *
+     * Symbol: `m²/s`
+     * SI: `m²·s⁻¹`
+     *
+     * @see KinematicViscosity
+     */
+    typealias SquareMetrePerSecond = Quotient<SquareMetre, Second>
 }

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/LinearMassDensity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/LinearMassDensity.kt
@@ -8,19 +8,6 @@ import org.kisu.units.representation.Quotient
 import java.math.BigDecimal
 
 /**
- * Unit of [LinearMassDensity].
- *
- * Represents the unit of **linear mass density**, i.e., the physical quantity measuring
- * mass per unit length.
- *
- * Symbol: `kg/m`
- * SI: `kg·m⁻¹`
- *
- * @see LinearMassDensity
- */
-typealias KilogramPerMetre = Quotient<Kilogram, Metre>
-
-/**
  * Measure of linear mass density expressed in [KilogramPerMetre].
  *
  * Linear mass density quantifies the amount of mass distributed along a line or slender object.
@@ -38,7 +25,24 @@ typealias KilogramPerMetre = Quotient<Kilogram, Metre>
 class LinearMassDensity(
     magnitude: BigDecimal,
     expression: KilogramPerMetre
-) : Measure<KilogramPerMetre, LinearMassDensity>(magnitude, expression, ::LinearMassDensity) {
+) : Measure<LinearMassDensity.KilogramPerMetre, LinearMassDensity>(
+    magnitude = magnitude,
+    expression = expression,
+    create = ::LinearMassDensity
+) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Kilogram(prefix to BigDecimal.ONE), Metre()))
+
+    /**
+     * Unit of [LinearMassDensity].
+     *
+     * Represents the unit of **linear mass density**, i.e., the physical quantity measuring
+     * mass per unit length.
+     *
+     * Symbol: `kg/m`
+     * SI: `kg·m⁻¹`
+     *
+     * @see LinearMassDensity
+     */
+    typealias KilogramPerMetre = Quotient<Kilogram, Metre>
 }

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/MassFlowRate.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/MassFlowRate.kt
@@ -8,19 +8,6 @@ import org.kisu.units.representation.Quotient
 import java.math.BigDecimal
 
 /**
- * Unit of [MassFlowRate].
- *
- * Represents the unit of **mass flow rate**, i.e., the physical quantity measuring
- * mass transported per unit time.
- *
- * Symbol: `kg/s`
- * SI: `kg·s⁻¹`
- *
- * @see MassFlowRate
- */
-typealias KilogramPerSecond = Quotient<Kilogram, Second>
-
-/**
  * Measure of mass flow rate expressed in [KilogramPerSecond].
  *
  * Mass flow rate quantifies how much mass passes through a given surface or section per unit time.
@@ -38,7 +25,20 @@ typealias KilogramPerSecond = Quotient<Kilogram, Second>
 class MassFlowRate(
     magnitude: BigDecimal,
     expression: KilogramPerSecond
-) : Measure<KilogramPerSecond, MassFlowRate>(magnitude, expression, ::MassFlowRate) {
+) : Measure<MassFlowRate.KilogramPerSecond, MassFlowRate>(magnitude, expression, ::MassFlowRate) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Kilogram(prefix to BigDecimal.ONE), Second()))
+
+    /**
+     * Unit of [MassFlowRate].
+     *
+     * Represents the unit of **mass flow rate**, i.e., the physical quantity measuring
+     * mass transported per unit time.
+     *
+     * Symbol: `kg/s`
+     * SI: `kg·s⁻¹`
+     *
+     * @see MassFlowRate
+     */
+    typealias KilogramPerSecond = Quotient<Kilogram, Second>
 }

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/MomentOfIntertia.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/MomentOfIntertia.kt
@@ -8,19 +8,6 @@ import org.kisu.units.special.SquareMetre
 import java.math.BigDecimal
 
 /**
- * Unit of [MomentOfIntertia].
- *
- * Represents the unit of **moment of inertia**, i.e., the physical quantity measuring
- * an object's resistance to rotational acceleration about an axis.
- *
- * Symbol: `kg·m²`
- * SI: `kg·m²`
- *
- * @see MomentOfIntertia
- */
-typealias KilogramSquareMetre = Product<Kilogram, SquareMetre>
-
-/**
  * Measure of moment of inertia expressed in [KilogramSquareMetre].
  *
  * Moment of inertia quantifies how mass is distributed relative to a rotation axis,
@@ -39,7 +26,24 @@ typealias KilogramSquareMetre = Product<Kilogram, SquareMetre>
 class MomentOfIntertia(
     magnitude: BigDecimal,
     expression: KilogramSquareMetre
-) : Measure<KilogramSquareMetre, MomentOfIntertia>(magnitude, expression, ::MomentOfIntertia) {
+) : Measure<MomentOfIntertia.KilogramSquareMetre, MomentOfIntertia>(
+    magnitude = magnitude,
+    expression = expression,
+    create = ::MomentOfIntertia
+) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Product(Kilogram(prefix to BigDecimal.ONE), SquareMetre()))
+
+    /**
+     * Unit of [MomentOfIntertia].
+     *
+     * Represents the unit of **moment of inertia**, i.e., the physical quantity measuring
+     * an object's resistance to rotational acceleration about an axis.
+     *
+     * Symbol: `kg·m²`
+     * SI: `kg·m²`
+     *
+     * @see MomentOfIntertia
+     */
+    typealias KilogramSquareMetre = Product<Kilogram, SquareMetre>
 }

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/Momentum.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/Momentum.kt
@@ -8,19 +8,6 @@ import org.kisu.units.special.Newton
 import java.math.BigDecimal
 
 /**
- * Unit of [Momentum].
- *
- * Represents the unit of **momentum**, i.e., the physical quantity measuring
- * the product of mass and velocity of a body.
- *
- * Symbol: `N·s`
- * SI: `kg·m·s⁻¹`
- *
- * @see Momentum
- */
-typealias NewtonSecond = Product<Newton, Second>
-
-/**
  * Measure of momentum expressed in [NewtonSecond].
  *
  * Momentum quantifies the motion of a body, combining its mass and velocity,
@@ -39,7 +26,20 @@ typealias NewtonSecond = Product<Newton, Second>
 class Momentum(
     magnitude: BigDecimal,
     expression: NewtonSecond
-) : Measure<NewtonSecond, Momentum>(magnitude, expression, ::Momentum) {
+) : Measure<Momentum.NewtonSecond, Momentum>(magnitude, expression, ::Momentum) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Product(Newton(prefix), Second()))
+
+    /**
+     * Unit of [Momentum].
+     *
+     * Represents the unit of **momentum**, i.e., the physical quantity measuring
+     * the product of mass and velocity of a body.
+     *
+     * Symbol: `N·s`
+     * SI: `kg·m·s⁻¹`
+     *
+     * @see Momentum
+     */
+    typealias NewtonSecond = Product<Newton, Second>
 }

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/Radiance.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/Radiance.kt
@@ -10,19 +10,6 @@ import org.kisu.units.special.Watt
 import java.math.BigDecimal
 
 /**
- * Unit of [Radiance].
- *
- * Represents the unit of **radiance**, i.e., the physical quantity measuring
- * radiant power emitted per unit area per unit solid angle.
- *
- * Symbol: `W/(sr·m²)`
- * SI: `kg·s⁻³`
- *
- * @see Radiance
- */
-typealias WattPerSteradianSquareMetre = Quotient<Watt, Product<Steradian, SquareMetre>>
-
-/**
  * Measure of radiance expressed in [WattPerSteradianSquareMetre].
  *
  * Radiance quantifies the intensity of electromagnetic radiation in a specific
@@ -41,7 +28,20 @@ typealias WattPerSteradianSquareMetre = Quotient<Watt, Product<Steradian, Square
 class Radiance(
     magnitude: BigDecimal,
     expression: WattPerSteradianSquareMetre
-) : Measure<WattPerSteradianSquareMetre, Radiance>(magnitude, expression, ::Radiance) {
+) : Measure<Radiance.WattPerSteradianSquareMetre, Radiance>(magnitude, expression, ::Radiance) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Watt(prefix), Product(Steradian(), SquareMetre())))
+
+    /**
+     * Unit of [Radiance].
+     *
+     * Represents the unit of **radiance**, i.e., the physical quantity measuring
+     * radiant power emitted per unit area per unit solid angle.
+     *
+     * Symbol: `W/(sr·m²)`
+     * SI: `kg·s⁻³`
+     *
+     * @see Radiance
+     */
+    typealias WattPerSteradianSquareMetre = Quotient<Watt, Product<Steradian, SquareMetre>>
 }

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/RadiantExposure.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/RadiantExposure.kt
@@ -8,19 +8,6 @@ import org.kisu.units.special.SquareMetre
 import java.math.BigDecimal
 
 /**
- * Unit of [RadiantExposure].
- *
- * Represents the unit of **radiant exposure**, i.e., the physical quantity measuring
- * energy received per unit area from electromagnetic radiation.
- *
- * Symbol: `J/m²`
- * SI: `kg·s⁻²`
- *
- * @see RadiantExposure
- */
-typealias JoulePerSquareMetre = Quotient<Joule, SquareMetre>
-
-/**
  * Measure of radiant exposure expressed in [JoulePerSquareMetre].
  *
  * Radiant exposure quantifies the total energy incident on a surface per unit area,
@@ -39,7 +26,24 @@ typealias JoulePerSquareMetre = Quotient<Joule, SquareMetre>
 class RadiantExposure(
     magnitude: BigDecimal,
     expression: JoulePerSquareMetre
-) : Measure<JoulePerSquareMetre, RadiantExposure>(magnitude, expression, ::RadiantExposure) {
+) : Measure<RadiantExposure.JoulePerSquareMetre, RadiantExposure>(
+    magnitude = magnitude,
+    expression = expression,
+    create = ::RadiantExposure
+) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Joule(prefix), SquareMetre()))
+
+    /**
+     * Unit of [RadiantExposure].
+     *
+     * Represents the unit of **radiant exposure**, i.e., the physical quantity measuring
+     * energy received per unit area from electromagnetic radiation.
+     *
+     * Symbol: `J/m²`
+     * SI: `kg·s⁻²`
+     *
+     * @see RadiantExposure
+     */
+    typealias JoulePerSquareMetre = Quotient<Joule, SquareMetre>
 }

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/RadiantIntensity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/RadiantIntensity.kt
@@ -8,19 +8,6 @@ import org.kisu.units.special.Watt
 import java.math.BigDecimal
 
 /**
- * Unit of [RadiantIntensity].
- *
- * Represents the unit of **radiant intensity**, i.e., the physical quantity measuring
- * radiant power emitted per unit solid angle.
- *
- * Symbol: `W/sr`
- * SI: `kg·m²·s⁻³`
- *
- * @see RadiantIntensity
- */
-typealias WattPerSteradian = Quotient<Watt, Steradian>
-
-/**
  * Measure of radiant intensity expressed in [WattPerSteradian].
  *
  * Radiant intensity quantifies the distribution of radiated power in a particular direction.
@@ -38,7 +25,20 @@ typealias WattPerSteradian = Quotient<Watt, Steradian>
 class RadiantIntensity(
     magnitude: BigDecimal,
     expression: WattPerSteradian
-) : Measure<WattPerSteradian, RadiantIntensity>(magnitude, expression, ::RadiantIntensity) {
+) : Measure<RadiantIntensity.WattPerSteradian, RadiantIntensity>(magnitude, expression, ::RadiantIntensity) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Watt(prefix), Steradian()))
+
+    /**
+     * Unit of [RadiantIntensity].
+     *
+     * Represents the unit of **radiant intensity**, i.e., the physical quantity measuring
+     * radiant power emitted per unit solid angle.
+     *
+     * Symbol: `W/sr`
+     * SI: `kg·m²·s⁻³`
+     *
+     * @see RadiantIntensity
+     */
+    typealias WattPerSteradian = Quotient<Watt, Steradian>
 }

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/SpecificAngularMomentum.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/SpecificAngularMomentum.kt
@@ -11,19 +11,6 @@ import org.kisu.units.special.Newton
 import java.math.BigDecimal
 
 /**
- * Unit of [SpecificAngularMomentum].
- *
- * Represents the unit of **specific angular momentum**, i.e., the physical quantity measuring
- * angular momentum per unit mass.
- *
- * Symbol: `N·m·s/kg`
- * SI: `m²·s⁻¹`
- *
- * @see SpecificAngularMomentum
- */
-typealias NewtonMetreSecondPerKilogram = Quotient<NewtonMeterSecond, Kilogram>
-
-/**
  * Measure of specific angular momentum expressed in [NewtonMetreSecondPerKilogram].
  *
  * Specific angular momentum quantifies the rotational motion of an object normalized by its mass,
@@ -42,7 +29,7 @@ typealias NewtonMetreSecondPerKilogram = Quotient<NewtonMeterSecond, Kilogram>
 class SpecificAngularMomentum(
     magnitude: BigDecimal,
     expression: NewtonMetreSecondPerKilogram
-) : Measure<NewtonMetreSecondPerKilogram, SpecificAngularMomentum>(
+) : Measure<SpecificAngularMomentum.NewtonMetreSecondPerKilogram, SpecificAngularMomentum>(
     magnitude,
     expression,
     ::SpecificAngularMomentum
@@ -55,4 +42,17 @@ class SpecificAngularMomentum(
                 Kilogram()
             )
         )
+
+    /**
+     * Unit of [SpecificAngularMomentum].
+     *
+     * Represents the unit of **specific angular momentum**, i.e., the physical quantity measuring
+     * angular momentum per unit mass.
+     *
+     * Symbol: `N·m·s/kg`
+     * SI: `m²·s⁻¹`
+     *
+     * @see SpecificAngularMomentum
+     */
+    typealias NewtonMetreSecondPerKilogram = Quotient<AngularMomentum.NewtonMeterSecond, Kilogram>
 }

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/SpecificEnergy.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/SpecificEnergy.kt
@@ -8,19 +8,6 @@ import org.kisu.units.special.Joule
 import java.math.BigDecimal
 
 /**
- * Unit of [SpecificEnergy].
- *
- * Represents the unit of **specific energy**, i.e., the physical quantity measuring
- * energy per unit mass.
- *
- * Symbol: `J/kg`
- * SI: `m²·s⁻²`
- *
- * @see SpecificEnergy
- */
-typealias JoulePerKilogram = Quotient<Joule, Kilogram>
-
-/**
  * Measure of specific energy expressed in [JoulePerKilogram].
  *
  * Specific energy quantifies the amount of energy contained or transferred per unit mass,
@@ -39,7 +26,20 @@ typealias JoulePerKilogram = Quotient<Joule, Kilogram>
 class SpecificEnergy(
     magnitude: BigDecimal,
     expression: JoulePerKilogram
-) : Measure<JoulePerKilogram, SpecificEnergy>(magnitude, expression, ::SpecificEnergy) {
+) : Measure<SpecificEnergy.JoulePerKilogram, SpecificEnergy>(magnitude, expression, ::SpecificEnergy) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Joule(prefix), Kilogram()))
+
+    /**
+     * Unit of [SpecificEnergy].
+     *
+     * Represents the unit of **specific energy**, i.e., the physical quantity measuring
+     * energy per unit mass.
+     *
+     * Symbol: `J/kg`
+     * SI: `m²·s⁻²`
+     *
+     * @see SpecificEnergy
+     */
+    typealias JoulePerKilogram = Quotient<Joule, Kilogram>
 }

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/SpecificVolume.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/SpecificVolume.kt
@@ -8,19 +8,6 @@ import org.kisu.units.special.CubicMetre
 import java.math.BigDecimal
 
 /**
- * Unit of [SpecificVolume].
- *
- * Represents the unit of **specific volume**, i.e., the physical quantity measuring
- * volume per unit mass.
- *
- * Symbol: `m³/kg`
- * SI: `m³·kg⁻¹`
- *
- * @see SpecificVolume
- */
-typealias CubicMetrePerKilogram = Quotient<CubicMetre, Kilogram>
-
-/**
  * Measure of specific volume expressed in [CubicMetrePerKilogram].
  *
  * Specific volume quantifies the space occupied by a unit mass of a substance,
@@ -39,7 +26,20 @@ typealias CubicMetrePerKilogram = Quotient<CubicMetre, Kilogram>
 class SpecificVolume(
     magnitude: BigDecimal,
     expression: CubicMetrePerKilogram
-) : Measure<CubicMetrePerKilogram, SpecificVolume>(magnitude, expression, ::SpecificVolume) {
+) : Measure<SpecificVolume.CubicMetrePerKilogram, SpecificVolume>(magnitude, expression, ::SpecificVolume) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(CubicMetre(prefix), Kilogram()))
+
+    /**
+     * Unit of [SpecificVolume].
+     *
+     * Represents the unit of **specific volume**, i.e., the physical quantity measuring
+     * volume per unit mass.
+     *
+     * Symbol: `m³/kg`
+     * SI: `m³·kg⁻¹`
+     *
+     * @see SpecificVolume
+     */
+    typealias CubicMetrePerKilogram = Quotient<CubicMetre, Kilogram>
 }

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/SpectralIrradiance.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/SpectralIrradiance.kt
@@ -8,19 +8,6 @@ import org.kisu.units.special.Watt
 import java.math.BigDecimal
 
 /**
- * Unit of [SpectralIrradiance].
- *
- * Represents the unit of **spectral irradiance**, i.e., the physical quantity measuring
- * radiant power per unit volume.
- *
- * Symbol: `W/m³`
- * SI: `kg·m⁻¹·s⁻³`
- *
- * @see SpectralIrradiance
- */
-typealias WattPerCubicMetre = Quotient<Watt, CubicMetre>
-
-/**
  * Measure of spectral irradiance expressed in [WattPerCubicMetre].
  *
  * Spectral irradiance quantifies the distribution of radiant power within a given volume,
@@ -39,7 +26,24 @@ typealias WattPerCubicMetre = Quotient<Watt, CubicMetre>
 class SpectralIrradiance(
     magnitude: BigDecimal,
     expression: WattPerCubicMetre
-) : Measure<WattPerCubicMetre, SpectralIrradiance>(magnitude, expression, ::SpectralIrradiance) {
+) : Measure<SpectralIrradiance.WattPerCubicMetre, SpectralIrradiance>(
+    magnitude = magnitude,
+    expression = expression,
+    create = ::SpectralIrradiance
+) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Watt(prefix), CubicMetre()))
+
+    /**
+     * Unit of [SpectralIrradiance].
+     *
+     * Represents the unit of **spectral irradiance**, i.e., the physical quantity measuring
+     * radiant power per unit volume.
+     *
+     * Symbol: `W/m³`
+     * SI: `kg·m⁻¹·s⁻³`
+     *
+     * @see SpectralIrradiance
+     */
+    typealias WattPerCubicMetre = Quotient<Watt, CubicMetre>
 }

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/SpectralPower.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/SpectralPower.kt
@@ -8,19 +8,6 @@ import org.kisu.units.special.Watt
 import java.math.BigDecimal
 
 /**
- * Unit of [SpectralPower].
- *
- * Represents the unit of **spectral power**, i.e., the physical quantity measuring
- * radiant power per unit length.
- *
- * Symbol: `W/m`
- * SI: `kg·s⁻³`
- *
- * @see SpectralPower
- */
-typealias WattPerMetre = Quotient<Watt, Metre>
-
-/**
  * Measure of spectral power expressed in [WattPerMetre].
  *
  * Spectral power quantifies the distribution of radiant power along a specific length,
@@ -39,7 +26,20 @@ typealias WattPerMetre = Quotient<Watt, Metre>
 class SpectralPower(
     magnitude: BigDecimal,
     expression: WattPerMetre
-) : Measure<WattPerMetre, SpectralPower>(magnitude, expression, ::SpectralPower) {
+) : Measure<SpectralPower.WattPerMetre, SpectralPower>(magnitude, expression, ::SpectralPower) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Watt(prefix), Metre()))
+
+    /**
+     * Unit of [SpectralPower].
+     *
+     * Represents the unit of **spectral power**, i.e., the physical quantity measuring
+     * radiant power per unit length.
+     *
+     * Symbol: `W/m`
+     * SI: `kg·s⁻³`
+     *
+     * @see SpectralPower
+     */
+    typealias WattPerMetre = Quotient<Watt, Metre>
 }

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/SpectralRadiance.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/SpectralRadiance.kt
@@ -10,19 +10,6 @@ import org.kisu.units.special.Watt
 import java.math.BigDecimal
 
 /**
- * Unit of [SpectralRadiance].
- *
- * Represents the unit of **spectral radiance**, i.e., the physical quantity measuring
- * radiant power per unit volume per unit solid angle.
- *
- * Symbol: `W/(sr·m³)`
- * SI: `kg·m⁻¹·s⁻³`
- *
- * @see SpectralRadiance
- */
-typealias WattPerSteradianCubicMetre = Quotient<Watt, Product<Steradian, CubicMetre>>
-
-/**
  * Measure of spectral radiance expressed in [WattPerSteradianCubicMetre].
  *
  * Spectral radiance quantifies the directional distribution of radiant power within a
@@ -41,7 +28,24 @@ typealias WattPerSteradianCubicMetre = Quotient<Watt, Product<Steradian, CubicMe
 class SpectralRadiance(
     magnitude: BigDecimal,
     expression: WattPerSteradianCubicMetre
-) : Measure<WattPerSteradianCubicMetre, SpectralRadiance>(magnitude, expression, ::SpectralRadiance) {
+) : Measure<SpectralRadiance.WattPerSteradianCubicMetre, SpectralRadiance>(
+    magnitude = magnitude,
+    expression = expression,
+    create = ::SpectralRadiance
+) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Watt(prefix), Product(Steradian(), CubicMetre())))
+
+    /**
+     * Unit of [SpectralRadiance].
+     *
+     * Represents the unit of **spectral radiance**, i.e., the physical quantity measuring
+     * radiant power per unit volume per unit solid angle.
+     *
+     * Symbol: `W/(sr·m³)`
+     * SI: `kg·m⁻¹·s⁻³`
+     *
+     * @see SpectralRadiance
+     */
+    typealias WattPerSteradianCubicMetre = Quotient<Watt, Product<Steradian, CubicMetre>>
 }

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/Spectralntensity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/Spectralntensity.kt
@@ -10,19 +10,6 @@ import org.kisu.units.special.Watt
 import java.math.BigDecimal
 
 /**
- * Unit of [Spectralntensity].
- *
- * Represents the unit of **spectral intensity**, i.e., the physical quantity measuring
- * radiant power per unit length per unit solid angle.
- *
- * Symbol: `W/(sr·m)`
- * SI: `kg·s⁻³`
- *
- * @see Spectralntensity
- */
-typealias WattPerSteradianMetre = Quotient<Watt, Product<Steradian, Metre>>
-
-/**
  * Measure of spectral intensity expressed in [WattPerSteradianMetre].
  *
  * Spectral intensity quantifies the distribution of radiant power along a specific direction
@@ -41,7 +28,24 @@ typealias WattPerSteradianMetre = Quotient<Watt, Product<Steradian, Metre>>
 class Spectralntensity(
     magnitude: BigDecimal,
     expression: WattPerSteradianMetre
-) : Measure<WattPerSteradianMetre, Spectralntensity>(magnitude, expression, ::Spectralntensity) {
+) : Measure<Spectralntensity.WattPerSteradianMetre, Spectralntensity>(
+    magnitude = magnitude,
+    expression = expression,
+    create = ::Spectralntensity
+) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Watt(prefix), Product(Steradian(), Metre())))
+
+    /**
+     * Unit of [Spectralntensity].
+     *
+     * Represents the unit of **spectral intensity**, i.e., the physical quantity measuring
+     * radiant power per unit length per unit solid angle.
+     *
+     * Symbol: `W/(sr·m)`
+     * SI: `kg·s⁻³`
+     *
+     * @see Spectralntensity
+     */
+    typealias WattPerSteradianMetre = Quotient<Watt, Product<Steradian, Metre>>
 }

--- a/lib/src/main/kotlin/org/kisu/units/mechanics/SurfaceTension.kt
+++ b/lib/src/main/kotlin/org/kisu/units/mechanics/SurfaceTension.kt
@@ -8,19 +8,6 @@ import org.kisu.units.special.Newton
 import java.math.BigDecimal
 
 /**
- * Unit of [SurfaceTension].
- *
- * Represents the unit of **surface tension**, i.e., the physical quantity measuring
- * force per unit length along a liquid surface.
- *
- * Symbol: `N/m`
- * SI: `kg·s⁻²`
- *
- * @see SurfaceTension
- */
-typealias NewtonPerMetre = Quotient<Newton, Metre>
-
-/**
  * Measure of surface tension expressed in [NewtonPerMetre].
  *
  * Surface tension quantifies the cohesive force at the interface of a liquid,
@@ -39,7 +26,20 @@ typealias NewtonPerMetre = Quotient<Newton, Metre>
 class SurfaceTension(
     magnitude: BigDecimal,
     expression: NewtonPerMetre
-) : Measure<NewtonPerMetre, SurfaceTension>(magnitude, expression, ::SurfaceTension) {
+) : Measure<SurfaceTension.NewtonPerMetre, SurfaceTension>(magnitude, expression, ::SurfaceTension) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, Quotient(Newton(prefix), Metre()))
+
+    /**
+     * Unit of [SurfaceTension].
+     *
+     * Represents the unit of **surface tension**, i.e., the physical quantity measuring
+     * force per unit length along a liquid surface.
+     *
+     * Symbol: `N/m`
+     * SI: `kg·s⁻²`
+     *
+     * @see SurfaceTension
+     */
+    typealias NewtonPerMetre = Quotient<Newton, Metre>
 }

--- a/lib/src/main/kotlin/org/kisu/units/photometric/Efficacy.kt
+++ b/lib/src/main/kotlin/org/kisu/units/photometric/Efficacy.kt
@@ -7,27 +7,6 @@ import org.kisu.units.special.Lumen
 import org.kisu.units.special.Watt
 import java.math.BigDecimal
 
-typealias LumenPerWatt = Quotient<Lumen, Watt>
-
-/**
- * Creates a measure of **lumens per watt** (lm/W).
- *
- * This derived unit expresses luminous efficacy — how much visible
- * light (luminous flux) is produced per unit of power.
- *
- * Internally this returns a [Quotient] of:
- *  - a [Lumen] (luminous flux) with the specified [prefix]
- *  - divided by a [Watt] (power)
- *
- * @param prefix Metric prefix to apply to the lumen unit.
- * Defaults to [Metric.BASE] (no prefix).
- *
- * @return A [Quotient] representing lm/W.
- */
-@Suppress("FunctionNaming")
-internal fun LumenPerWatt(prefix: Metric = Metric.BASE): Quotient<Lumen, Watt> =
-    Quotient(Lumen(prefix), Watt())
-
 /**
  * Represents the **luminous efficacy** of a light source.
  *
@@ -45,7 +24,44 @@ internal fun LumenPerWatt(prefix: Metric = Metric.BASE): Quotient<Lumen, Watt> =
 class Efficacy(
     magnitude: BigDecimal,
     expression: LumenPerWatt
-) : Measure<LumenPerWatt, Efficacy>(magnitude, expression, ::Efficacy) {
+) : Measure<Efficacy.LumenPerWatt, Efficacy>(magnitude, expression, ::Efficacy) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, LumenPerWatt(prefix))
+
+    /**
+     * Represents the SI unit **lumen per watt (lm/W)**.
+     *
+     * This unit is used to measure **luminous efficacy**,
+     * i.e., the efficiency with which a light source converts electrical power into visible light.
+     * It is defined as the [Quotient] of [Lumen] (luminous flux) divided by [Watt] (power).
+     *
+     * Example usages include:
+     * - Comparing the efficiency of different light bulbs or LEDs
+     * - Designing energy-efficient lighting systems
+     * - Evaluating performance in photometry and lighting engineering
+     *
+     * @see Efficacy
+     */
+    typealias LumenPerWatt = Quotient<Lumen, Watt>
+
+    companion object {
+        /**
+         * Creates a measure of **lumens per watt** (lm/W).
+         *
+         * This derived unit expresses luminous efficacy — how much visible
+         * light (luminous flux) is produced per unit of power.
+         *
+         * Internally this returns a [Quotient] of:
+         *  - a [Lumen] (luminous flux) with the specified [prefix]
+         *  - divided by a [Watt] (power)
+         *
+         * @param prefix Metric prefix to apply to the lumen unit.
+         * Defaults to [Metric.BASE] (no prefix).
+         *
+         * @return A [Quotient] representing lm/W.
+         */
+        @Suppress("FunctionNaming")
+        internal fun LumenPerWatt(prefix: Metric = Metric.BASE): Quotient<Lumen, Watt> =
+            Quotient(Lumen(prefix), Watt())
+    }
 }

--- a/lib/src/main/kotlin/org/kisu/units/photometric/Exposure.kt
+++ b/lib/src/main/kotlin/org/kisu/units/photometric/Exposure.kt
@@ -7,27 +7,6 @@ import org.kisu.units.representation.Product
 import org.kisu.units.special.Lux
 import java.math.BigDecimal
 
-typealias LuxSecond = Product<Lux, Second>
-
-/**
- * Creates a measure of **lux-seconds** (lx·s).
- *
- * This derived unit expresses luminous exposure — the total
- * illumination received over a period of time.
- *
- * Internally this returns a [Product] of:
- *  - a [Lux] (illuminance) with the specified [prefix]
- *  - multiplied by a [Second] (time)
- *
- * @param prefix Metric prefix to apply to the lux unit.
- * Defaults to [Metric.BASE] (no prefix).
- *
- * @return A [Product] representing lx·s.
- */
-@Suppress("FunctionNaming")
-internal fun LuxSecond(prefix: Metric = Metric.BASE): Product<Lux, Second> =
-    Product(Lux(prefix), Second())
-
 /**
  * Represents **luminous exposure**.
  *
@@ -48,7 +27,44 @@ internal fun LuxSecond(prefix: Metric = Metric.BASE): Product<Lux, Second> =
 class Exposure(
     magnitude: BigDecimal,
     expression: LuxSecond
-) : Measure<LuxSecond, Exposure>(magnitude, expression, ::Exposure) {
+) : Measure<Exposure.LuxSecond, Exposure>(magnitude, expression, ::Exposure) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, LuxSecond(prefix))
+
+    /**
+     * Represents the SI unit **lux second (lx·s)**.
+     *
+     * This unit is used to measure **illuminance exposure**,
+     * i.e., the total light received over a period of time.
+     * It is defined as the [Product] of [Lux] (illuminance) and [Second] (time).
+     *
+     * Example usages include:
+     * - Quantifying light exposure for photographic or cinematographic purposes
+     * - Measuring accumulated illumination in plant growth studies
+     * - Assessing dosages in light therapy or photobiology
+     *
+     * @see Exposure
+     */
+    typealias LuxSecond = Product<Lux, Second>
+
+    companion object {
+        /**
+         * Creates a measure of **lux-seconds** (lx·s).
+         *
+         * This derived unit expresses luminous exposure — the total
+         * illumination received over a period of time.
+         *
+         * Internally this returns a [Product] of:
+         *  - a [Lux] (illuminance) with the specified [prefix]
+         *  - multiplied by a [Second] (time)
+         *
+         * @param prefix Metric prefix to apply to the lux unit.
+         * Defaults to [Metric.BASE] (no prefix).
+         *
+         * @return A [Product] representing lx·s.
+         */
+        @Suppress("FunctionNaming")
+        internal fun LuxSecond(prefix: Metric = Metric.BASE): Product<Lux, Second> =
+            Product(Lux(prefix), Second())
+    }
 }

--- a/lib/src/main/kotlin/org/kisu/units/photometric/Luminance.kt
+++ b/lib/src/main/kotlin/org/kisu/units/photometric/Luminance.kt
@@ -7,27 +7,6 @@ import org.kisu.units.representation.Quotient
 import org.kisu.units.special.SquareMetre
 import java.math.BigDecimal
 
-typealias CandelaPerSquareMetre = Quotient<Candela, SquareMetre>
-
-/**
- * Creates a measure of **candelas per square metre** (cd/m²).
- *
- * This derived unit expresses luminance — the amount of luminous
- * intensity emitted or reflected per unit area.
- *
- * Internally this returns a [Quotient] of:
- *  - a [Candela] (luminous intensity) with the specified [prefix]
- *  - divided by a [SquareMetre] (area)
- *
- * @param prefix Metric prefix to apply to the candela unit.
- * Defaults to [Metric.BASE] (no prefix).
- *
- * @return A [Quotient] representing cd/m².
- */
-@Suppress("FunctionNaming")
-internal fun CandelaPerSquareMetre(prefix: Metric = Metric.BASE): Quotient<Candela, SquareMetre> =
-    Quotient(Candela(prefix), SquareMetre())
-
 /**
  * Represents **luminance**.
  *
@@ -50,7 +29,44 @@ internal fun CandelaPerSquareMetre(prefix: Metric = Metric.BASE): Quotient<Cande
 class Luminance(
     magnitude: BigDecimal,
     expression: CandelaPerSquareMetre
-) : Measure<CandelaPerSquareMetre, Luminance>(magnitude, expression, ::Luminance) {
+) : Measure<Luminance.CandelaPerSquareMetre, Luminance>(magnitude, expression, ::Luminance) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, CandelaPerSquareMetre(prefix))
+
+    /**
+     * Represents the SI unit **candela per square metre (cd/m²)**.
+     *
+     * This unit is used to measure **luminance**,
+     * i.e., the luminous intensity emitted per unit area in a given direction.
+     * It is defined as the [Quotient] of [Candela] (luminous intensity) divided by [SquareMetre] (area).
+     *
+     * Example usages include:
+     * - Specifying the brightness of screens, displays, or monitors
+     * - Measuring surface luminance in lighting design or photometry
+     * - Analysing visual comfort and visibility in architectural lighting
+     *
+     * @see Luminance
+     */
+    typealias CandelaPerSquareMetre = Quotient<Candela, SquareMetre>
+
+    companion object {
+        /**
+         * Creates a measure of **candelas per square metre** (cd/m²).
+         *
+         * This derived unit expresses luminance — the amount of luminous
+         * intensity emitted or reflected per unit area.
+         *
+         * Internally this returns a [Quotient] of:
+         *  - a [Candela] (luminous intensity) with the specified [prefix]
+         *  - divided by a [SquareMetre] (area)
+         *
+         * @param prefix Metric prefix to apply to the candela unit.
+         * Defaults to [Metric.BASE] (no prefix).
+         *
+         * @return A [Quotient] representing cd/m².
+         */
+        @Suppress("FunctionNaming")
+        internal fun CandelaPerSquareMetre(prefix: Metric = Metric.BASE): Quotient<Candela, SquareMetre> =
+            Quotient(Candela(prefix), SquareMetre())
+    }
 }

--- a/lib/src/main/kotlin/org/kisu/units/photometric/LuminousEnergy.kt
+++ b/lib/src/main/kotlin/org/kisu/units/photometric/LuminousEnergy.kt
@@ -7,27 +7,6 @@ import org.kisu.units.representation.Product
 import org.kisu.units.special.Lumen
 import java.math.BigDecimal
 
-typealias LumenSecond = Product<Lumen, Second>
-
-/**
- * Creates a measure of **lumen-seconds** (lm·s).
- *
- * This derived unit expresses luminous energy — the total
- * luminous flux emitted over a period of time.
- *
- * Internally this returns a [Product] of:
- *  - a [Lumen] (luminous flux) with the specified [prefix]
- *  - multiplied by a [Second] (time)
- *
- * @param prefix Metric prefix to apply to the lumen unit.
- * Defaults to [Metric.BASE] (no prefix).
- *
- * @return A [Product] representing lm·s.
- */
-@Suppress("FunctionNaming")
-internal fun LumenSecond(prefix: Metric = Metric.BASE): Product<Lumen, Second> =
-    Product(Lumen(prefix), Second())
-
 /**
  * Represents **luminous energy**.
  *
@@ -48,7 +27,44 @@ internal fun LumenSecond(prefix: Metric = Metric.BASE): Product<Lumen, Second> =
 class LuminousEnergy(
     magnitude: BigDecimal,
     expression: LumenSecond
-) : Measure<LumenSecond, LuminousEnergy>(magnitude, expression, ::LuminousEnergy) {
+) : Measure<LuminousEnergy.LumenSecond, LuminousEnergy>(magnitude, expression, ::LuminousEnergy) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, LumenSecond(prefix))
+
+    /**
+     * Represents the SI unit **lumen second (lm·s)**.
+     *
+     * This unit is used to measure **luminous energy**,
+     * i.e., the total amount of visible light emitted over a period of time.
+     * It is defined as the [Product] of [Lumen] (luminous flux) and [Second] (time).
+     *
+     * Example usages include:
+     * - Quantifying total light output of a source during a measurement period
+     * - Evaluating exposure in photometry experiments
+     * - Analysing energy delivered by light sources in lighting engineering
+     *
+     * @see LuminousEnergy
+     */
+    typealias LumenSecond = Product<Lumen, Second>
+
+    companion object {
+        /**
+         * Creates a measure of **lumen-seconds** (lm·s).
+         *
+         * This derived unit expresses luminous energy — the total
+         * luminous flux emitted over a period of time.
+         *
+         * Internally this returns a [Product] of:
+         *  - a [Lumen] (luminous flux) with the specified [prefix]
+         *  - multiplied by a [Second] (time)
+         *
+         * @param prefix Metric prefix to apply to the lumen unit.
+         * Defaults to [Metric.BASE] (no prefix).
+         *
+         * @return A [Product] representing lm·s.
+         */
+        @Suppress("FunctionNaming")
+        internal fun LumenSecond(prefix: Metric = Metric.BASE): Product<Lumen, Second> =
+            Product(Lumen(prefix), Second())
+    }
 }

--- a/lib/src/main/kotlin/org/kisu/units/representation/Product.kt
+++ b/lib/src/main/kotlin/org/kisu/units/representation/Product.kt
@@ -73,6 +73,7 @@ class Product<A, B>(
             .map { (_, group) ->
                 @Suppress("UNCHECKED_CAST")
                 val castedGroup = group as List<Scalar<Any, Any>>
+                @Suppress("UNCHECKED_CAST")
                 castedGroup.reduce { a, b -> (a + b) as Scalar<Any, Any> }
             }
             .filter { !it.zero }

--- a/lib/src/main/kotlin/org/kisu/units/thermodynamics/HeatCapacity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/thermodynamics/HeatCapacity.kt
@@ -8,40 +8,6 @@ import org.kisu.units.special.Joule
 import java.math.BigDecimal
 
 /**
- * Represents the SI unit **joule per kelvin (J/K)**.
- *
- * This unit measures **heat capacity**, i.e. the amount of energy required
- * to raise the temperature of a system by one kelvin.
- * It is defined as the [Quotient] of [Joule] (energy) divided by [Kelvin] (temperature).
- *
- * Example usages include:
- * - Total heat capacity of a system or object
- * - Thermodynamics and calorimetry calculations
- *
- * @see HeatCapacity for the physical quantity represented by this unit.
- */
-typealias JoulePerKelvin = Quotient<Joule, Kelvin>
-
-/**
- * Creates a measure of **joules per kelvin** (J/K).
- *
- * This derived unit is used to express heat capacity or entropy
- * per unit temperature.
- *
- * Internally this returns a [Quotient] of:
- *  - a [Joule] (energy) with the specified [prefix]
- *  - divided by a [Kelvin] (temperature)
- *
- * @param prefix Metric prefix to apply to the joule unit.
- * Defaults to [Metric.BASE] (no prefix).
- *
- * @return A [Quotient] representing J/K.
- */
-@Suppress("FunctionNaming")
-internal fun JoulePerKelvin(prefix: Metric = Metric.BASE): Quotient<Joule, Kelvin> =
-    Quotient(Joule(prefix), Kelvin())
-
-/**
  * Represents the physical quantity of **heat capacity**.
  *
  * Heat capacity quantifies the **amount of heat energy required to raise the temperature
@@ -63,7 +29,43 @@ internal fun JoulePerKelvin(prefix: Metric = Metric.BASE): Quotient<Joule, Kelvi
 class HeatCapacity(
     magnitude: BigDecimal,
     expression: JoulePerKelvin
-) : Measure<JoulePerKelvin, HeatCapacity>(magnitude, expression, ::HeatCapacity) {
+) : Measure<HeatCapacity.JoulePerKelvin, HeatCapacity>(magnitude, expression, ::HeatCapacity) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, JoulePerKelvin(prefix))
+
+    /**
+     * Represents the SI unit **joule per kelvin (J/K)**.
+     *
+     * This unit measures **heat capacity**, i.e. the amount of energy required
+     * to raise the temperature of a system by one kelvin.
+     * It is defined as the [Quotient] of [Joule] (energy) divided by [Kelvin] (temperature).
+     *
+     * Example usages include:
+     * - Total heat capacity of a system or object
+     * - Thermodynamics and calorimetry calculations
+     *
+     * @see HeatCapacity for the physical quantity represented by this unit.
+     */
+    typealias JoulePerKelvin = Quotient<Joule, Kelvin>
+
+    companion object {
+        /**
+         * Creates a measure of **joules per kelvin** (J/K).
+         *
+         * This derived unit is used to express heat capacity or entropy
+         * per unit temperature.
+         *
+         * Internally this returns a [Quotient] of:
+         *  - a [Joule] (energy) with the specified [prefix]
+         *  - divided by a [Kelvin] (temperature)
+         *
+         * @param prefix Metric prefix to apply to the joule unit.
+         * Defaults to [Metric.BASE] (no prefix).
+         *
+         * @return A [Quotient] representing J/K.
+         */
+        @Suppress("FunctionNaming")
+        internal fun JoulePerKelvin(prefix: Metric = Metric.BASE): Quotient<Joule, Kelvin> =
+            Quotient(Joule(prefix), Kelvin())
+    }
 }

--- a/lib/src/main/kotlin/org/kisu/units/thermodynamics/SpecificHeatCapacity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/thermodynamics/SpecificHeatCapacity.kt
@@ -10,45 +10,6 @@ import org.kisu.units.special.Joule
 import java.math.BigDecimal
 
 /**
- * Represents the SI unit **joule per kilogram kelvin (J/(kg·K))**.
- *
- * This unit measures **specific heat capacity**, i.e., the amount of energy required
- * to raise the temperature of one kilogram of a substance by one kelvin.
- * It is defined as the [Quotient] of [Joule] (energy) divided by the [Product] of
- * [Kilogram] (mass) and [Kelvin] (temperature).
- *
- * Example usages include:
- * - Specific heat capacity of water (~4184 J/(kg·K) at 25 °C)
- * - Material science and thermodynamics calculations
- *
- * @see SpecificHeatCapacity for the physical quantity represented by this unit.
- */
-typealias JoulePerKilogramKelvin = Quotient<Joule, Product<Kilogram, Kelvin>>
-
-/**
- * Creates a measure of **joules per kilogram-kelvin** (J/(kg·K)).
- *
- * This derived unit is used to express specific heat capacity or
- * specific entropy — energy per unit mass per unit temperature.
- *
- * Internally this returns a [Quotient] of:
- *  - a [Joule] (energy) with the specified [prefix]
- *  - divided by a [Product] of [Kilogram] (mass) with the specified [prefix]
- *    and [Kelvin] (temperature)
- *
- * @param prefix Metric prefix to apply to the kilogram unit.
- * Defaults to [Metric.BASE] (no prefix).
- *
- * @return A [Quotient] representing J/(kg·K).
- */
-@Suppress("FunctionNaming")
-internal fun JoulePerKilogramKelvin(prefix: Metric = Metric.BASE): Quotient<Joule, Product<Kilogram, Kelvin>> =
-    Quotient(
-        Joule(),
-        Product(Kilogram(prefix), Kelvin())
-    )
-
-/**
  * Represents the physical quantity of **specific heat capacity**.
  *
  * Specific heat capacity quantifies the **amount of heat energy required to raise the temperature
@@ -70,10 +31,55 @@ internal fun JoulePerKilogramKelvin(prefix: Metric = Metric.BASE): Quotient<Joul
 class SpecificHeatCapacity(
     magnitude: BigDecimal,
     expression: JoulePerKilogramKelvin
-) : Measure<JoulePerKilogramKelvin, SpecificHeatCapacity>(magnitude, expression, ::SpecificHeatCapacity) {
+) : Measure<SpecificHeatCapacity.JoulePerKilogramKelvin, SpecificHeatCapacity>(
+    magnitude = magnitude,
+    expression = expression,
+    create = ::SpecificHeatCapacity
+) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(
             magnitude,
             JoulePerKilogramKelvin(prefix)
         )
+
+    /**
+     * Represents the SI unit **joule per kilogram kelvin (J/(kg·K))**.
+     *
+     * This unit measures **specific heat capacity**, i.e., the amount of energy required
+     * to raise the temperature of one kilogram of a substance by one kelvin.
+     * It is defined as the [Quotient] of [Joule] (energy) divided by the [Product] of
+     * [Kilogram] (mass) and [Kelvin] (temperature).
+     *
+     * Example usages include:
+     * - Specific heat capacity of water (~4184 J/(kg·K) at 25 °C)
+     * - Material science and thermodynamics calculations
+     *
+     * @see SpecificHeatCapacity for the physical quantity represented by this unit.
+     */
+    typealias JoulePerKilogramKelvin = Quotient<Joule, Product<Kilogram, Kelvin>>
+
+    companion object {
+        /**
+         * Creates a measure of **joules per kilogram-kelvin** (J/(kg·K)).
+         *
+         * This derived unit is used to express specific heat capacity or
+         * specific entropy — energy per unit mass per unit temperature.
+         *
+         * Internally this returns a [Quotient] of:
+         *  - a [Joule] (energy) with the specified [prefix]
+         *  - divided by a [Product] of [Kilogram] (mass) with the specified [prefix]
+         *    and [Kelvin] (temperature)
+         *
+         * @param prefix Metric prefix to apply to the kilogram unit.
+         * Defaults to [Metric.BASE] (no prefix).
+         *
+         * @return A [Quotient] representing J/(kg·K).
+         */
+        @Suppress("FunctionNaming")
+        internal fun JoulePerKilogramKelvin(prefix: Metric = Metric.BASE): Quotient<Joule, Product<Kilogram, Kelvin>> =
+            Quotient(
+                Joule(),
+                Product(Kilogram(prefix), Kelvin())
+            )
+    }
 }

--- a/lib/src/main/kotlin/org/kisu/units/thermodynamics/TemperatureGradient.kt
+++ b/lib/src/main/kotlin/org/kisu/units/thermodynamics/TemperatureGradient.kt
@@ -8,41 +8,6 @@ import org.kisu.units.representation.Quotient
 import java.math.BigDecimal
 
 /**
- * Represents the SI unit **kelvin per metre (K/m)**.
- *
- * This unit measures a **temperature gradient**, i.e., the rate of change of temperature
- * with respect to distance.
- * It is defined as the [Quotient] of [Kelvin] (temperature) divided by [Metre] (length).
- *
- * Example usages include:
- * - Heat conduction through materials (Fourier’s law)
- * - Atmospheric or oceanic temperature gradients
- * - Thermal engineering calculations
- *
- * @see TemperatureGradient for the physical quantity represented by this unit.
- */
-typealias KelvinPerMetre = Quotient<Kelvin, Metre>
-
-/**
- * Creates a measure of **kelvins per metre** (K/m).
- *
- * This derived unit expresses a temperature gradient — the change
- * in temperature per unit length.
- *
- * Internally this returns a [Quotient] of:
- *  - a [Kelvin] (temperature difference) with the specified [prefix]
- *  - divided by a [Metre] (length)
- *
- * @param prefix Metric prefix to apply to the kelvin unit.
- * Defaults to [Metric.BASE] (no prefix).
- *
- * @return A [Quotient] representing K/m.
- */
-@Suppress("FunctionNaming")
-internal fun KelvinPerMetre(prefix: Metric = Metric.BASE): Quotient<Kelvin, Metre> =
-    Quotient(Kelvin(prefix), Metre())
-
-/**
  * Represents the physical quantity of **temperature gradient**.
  *
  * Temperature gradient quantifies the **rate of change of temperature with respect to distance**.
@@ -63,7 +28,48 @@ internal fun KelvinPerMetre(prefix: Metric = Metric.BASE): Quotient<Kelvin, Metr
 class TemperatureGradient(
     magnitude: BigDecimal,
     expression: KelvinPerMetre
-) : Measure<KelvinPerMetre, TemperatureGradient>(magnitude, expression, ::TemperatureGradient) {
+) : Measure<TemperatureGradient.KelvinPerMetre, TemperatureGradient>(
+    magnitude = magnitude,
+    expression = expression,
+    create = ::TemperatureGradient
+) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, KelvinPerMetre(prefix))
+
+    /**
+     * Represents the SI unit **kelvin per metre (K/m)**.
+     *
+     * This unit measures a **temperature gradient**, i.e., the rate of change of temperature
+     * with respect to distance.
+     * It is defined as the [Quotient] of [Kelvin] (temperature) divided by [Metre] (length).
+     *
+     * Example usages include:
+     * - Heat conduction through materials (Fourier’s law)
+     * - Atmospheric or oceanic temperature gradients
+     * - Thermal engineering calculations
+     *
+     * @see TemperatureGradient for the physical quantity represented by this unit.
+     */
+    typealias KelvinPerMetre = Quotient<Kelvin, Metre>
+
+    companion object {
+        /**
+         * Creates a measure of **kelvins per metre** (K/m).
+         *
+         * This derived unit expresses a temperature gradient — the change
+         * in temperature per unit length.
+         *
+         * Internally this returns a [Quotient] of:
+         *  - a [Kelvin] (temperature difference) with the specified [prefix]
+         *  - divided by a [Metre] (length)
+         *
+         * @param prefix Metric prefix to apply to the kelvin unit.
+         * Defaults to [Metric.BASE] (no prefix).
+         *
+         * @return A [Quotient] representing K/m.
+         */
+        @Suppress("FunctionNaming")
+        internal fun KelvinPerMetre(prefix: Metric = Metric.BASE): Quotient<Kelvin, Metre> =
+            Quotient(Kelvin(prefix), Metre())
+    }
 }

--- a/lib/src/main/kotlin/org/kisu/units/thermodynamics/ThermalConductivity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/thermodynamics/ThermalConductivity.kt
@@ -10,43 +10,6 @@ import org.kisu.units.special.Watt
 import java.math.BigDecimal
 
 /**
- * Represents the SI unit **watt per metre kelvin (W/(m·K))**.
- *
- * This unit measures **thermal conductivity**, i.e., the rate at which heat
- * energy passes through a material under a temperature gradient.
- * It is defined as the [Quotient] of [Watt] (power) divided by the [Product] of
- * [Metre] (length) and [Kelvin] (temperature).
- *
- * Example usages include:
- * - Characterizing materials (e.g., copper ≈ 401 W/(m·K), glass ≈ 1 W/(m·K))
- * - Heat transfer calculations in engineering and physics
- * - Thermal insulation design
- *
- * @see ThermalConductivity for the physical quantity represented by this unit.
- */
-typealias WattPerMetreKelvin = Quotient<Watt, Product<Metre, Kelvin>>
-
-/**
- * Creates a measure of **watts per metre-kelvin** (W/(m·K)).
- *
- * This derived unit expresses thermal conductivity — the rate of
- * heat transfer through a material per unit thickness and temperature
- * difference.
- *
- * Internally this returns a [Quotient] of:
- *  - a [Watt] (power) with the specified [prefix]
- *  - divided by a [Product] of [Metre] (length) and [Kelvin] (temperature)
- *
- * @param prefix Metric prefix to apply to the watt unit.
- * Defaults to [Metric.BASE] (no prefix).
- *
- * @return A [Quotient] representing W/(m·K).
- */
-@Suppress("FunctionNaming")
-internal fun WattPerMetreKelvin(prefix: Metric = Metric.BASE): Quotient<Watt, Product<Metre, Kelvin>> =
-    Quotient(Watt(prefix), Product(Metre(), Kelvin()))
-
-/**
  * Represents the physical quantity of **thermal conductivity**.
  *
  * Thermal conductivity quantifies a material’s **ability to conduct heat**.
@@ -69,7 +32,50 @@ internal fun WattPerMetreKelvin(prefix: Metric = Metric.BASE): Quotient<Watt, Pr
 class ThermalConductivity(
     magnitude: BigDecimal,
     expression: WattPerMetreKelvin
-) : Measure<WattPerMetreKelvin, ThermalConductivity>(magnitude, expression, ::ThermalConductivity) {
+) : Measure<ThermalConductivity.WattPerMetreKelvin, ThermalConductivity>(
+    magnitude = magnitude,
+    expression = expression,
+    create = ::ThermalConductivity
+) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, WattPerMetreKelvin(prefix))
+
+    /**
+     * Represents the SI unit **watt per metre kelvin (W/(m·K))**.
+     *
+     * This unit measures **thermal conductivity**, i.e., the rate at which heat
+     * energy passes through a material under a temperature gradient.
+     * It is defined as the [Quotient] of [Watt] (power) divided by the [Product] of
+     * [Metre] (length) and [Kelvin] (temperature).
+     *
+     * Example usages include:
+     * - Characterizing materials (e.g., copper ≈ 401 W/(m·K), glass ≈ 1 W/(m·K))
+     * - Heat transfer calculations in engineering and physics
+     * - Thermal insulation design
+     *
+     * @see ThermalConductivity for the physical quantity represented by this unit.
+     */
+    typealias WattPerMetreKelvin = Quotient<Watt, Product<Metre, Kelvin>>
+
+    companion object {
+        /**
+         * Creates a measure of **watts per metre-kelvin** (W/(m·K)).
+         *
+         * This derived unit expresses thermal conductivity — the rate of
+         * heat transfer through a material per unit thickness and temperature
+         * difference.
+         *
+         * Internally this returns a [Quotient] of:
+         *  - a [Watt] (power) with the specified [prefix]
+         *  - divided by a [Product] of [Metre] (length) and [Kelvin] (temperature)
+         *
+         * @param prefix Metric prefix to apply to the watt unit.
+         * Defaults to [Metric.BASE] (no prefix).
+         *
+         * @return A [Quotient] representing W/(m·K).
+         */
+        @Suppress("FunctionNaming")
+        internal fun WattPerMetreKelvin(prefix: Metric = Metric.BASE): Quotient<Watt, Product<Metre, Kelvin>> =
+            Quotient(Watt(prefix), Product(Metre(), Kelvin()))
+    }
 }

--- a/lib/src/main/kotlin/org/kisu/units/thermodynamics/ThermalResistance.kt
+++ b/lib/src/main/kotlin/org/kisu/units/thermodynamics/ThermalResistance.kt
@@ -8,41 +8,6 @@ import org.kisu.units.special.Watt
 import java.math.BigDecimal
 
 /**
- * Represents the SI unit **kelvin per watt (K/W)**.
- *
- * This unit measures **thermal resistance**, i.e., a material’s or system’s
- * opposition to heat flow.
- * It is defined as the [Quotient] of [Kelvin] (temperature difference) divided by [Watt] (heat flow rate).
- *
- * Example usages include:
- * - Evaluating insulation performance in buildings
- * - Thermal management of electronic components
- * - Heat transfer analysis in engineering systems
- *
- * @see ThermalResistance for the physical quantity represented by this unit.
- */
-typealias KelvinPerWatt = Quotient<Kelvin, Watt>
-
-/**
- * Creates a measure of **kelvins per watt** (K/W).
- *
- * This derived unit expresses thermal resistance — the temperature
- * difference per unit of power flow.
- *
- * Internally this returns a [Quotient] of:
- *  - a [Kelvin] (temperature difference) with the specified [prefix]
- *  - divided by a [Watt] (power)
- *
- * @param prefix Metric prefix to apply to the kelvin unit.
- * Defaults to [Metric.BASE] (no prefix).
- *
- * @return A [Quotient] representing K/W.
- */
-@Suppress("FunctionNaming")
-internal fun KelvinPerWatt(prefix: Metric = Metric.BASE): Quotient<Kelvin, Watt> =
-    Quotient(Kelvin(prefix), Watt())
-
-/**
  * Represents the physical quantity of **thermal resistance**.
  *
  * Thermal resistance quantifies a material’s or system’s **opposition to heat flow**.
@@ -65,7 +30,44 @@ internal fun KelvinPerWatt(prefix: Metric = Metric.BASE): Quotient<Kelvin, Watt>
 class ThermalResistance(
     magnitude: BigDecimal,
     expression: KelvinPerWatt
-) : Measure<KelvinPerWatt, ThermalResistance>(magnitude, expression, ::ThermalResistance) {
+) : Measure<ThermalResistance.KelvinPerWatt, ThermalResistance>(magnitude, expression, ::ThermalResistance) {
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, KelvinPerWatt(prefix))
+
+    /**
+     * Represents the SI unit **kelvin per watt (K/W)**.
+     *
+     * This unit measures **thermal resistance**, i.e., a material’s or system’s
+     * opposition to heat flow.
+     * It is defined as the [Quotient] of [Kelvin] (temperature difference) divided by [Watt] (heat flow rate).
+     *
+     * Example usages include:
+     * - Evaluating insulation performance in buildings
+     * - Thermal management of electronic components
+     * - Heat transfer analysis in engineering systems
+     *
+     * @see ThermalResistance for the physical quantity represented by this unit.
+     */
+    typealias KelvinPerWatt = Quotient<Kelvin, Watt>
+
+    companion object {
+        /**
+         * Creates a measure of **kelvins per watt** (K/W).
+         *
+         * This derived unit expresses thermal resistance — the temperature
+         * difference per unit of power flow.
+         *
+         * Internally this returns a [Quotient] of:
+         *  - a [Kelvin] (temperature difference) with the specified [prefix]
+         *  - divided by a [Watt] (power)
+         *
+         * @param prefix Metric prefix to apply to the kelvin unit.
+         * Defaults to [Metric.BASE] (no prefix).
+         *
+         * @return A [Quotient] representing K/W.
+         */
+        @Suppress("FunctionNaming")
+        internal fun KelvinPerWatt(prefix: Metric = Metric.BASE): Quotient<Kelvin, Watt> =
+            Quotient(Kelvin(prefix), Watt())
+    }
 }

--- a/lib/src/test/kotlin/org/kisu/units/chemistry/CatalyticEfficiencyTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/chemistry/CatalyticEfficiencyTest.kt
@@ -8,6 +8,7 @@ import io.kotest.property.checkAll
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
 import org.kisu.units.builders.cubicMetrePerMoleSecond
+import org.kisu.units.chemistry.CatalyticEfficiency.Companion.CubicMetrePerMoleSecond
 
 class CatalyticEfficiencyTest : StringSpec({
     "creates a CatalyticEfficiency" {

--- a/lib/src/test/kotlin/org/kisu/units/chemistry/MolalityTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/chemistry/MolalityTest.kt
@@ -8,6 +8,7 @@ import io.kotest.property.checkAll
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
 import org.kisu.units.builders.molPerKilogram
+import org.kisu.units.chemistry.Molality.Companion.MolPerKilogram
 
 class MolalityTest : StringSpec({
     "creates a Molality" {

--- a/lib/src/test/kotlin/org/kisu/units/chemistry/MolarConductivityTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/chemistry/MolarConductivityTest.kt
@@ -8,6 +8,7 @@ import io.kotest.property.checkAll
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
 import org.kisu.units.builders.siemensSquareMetrePerMole
+import org.kisu.units.chemistry.MolarConductivity.Companion.SiemensSquareMetrePerMole
 
 class MolarConductivityTest : StringSpec({
     "creates a MolarConductivity" {

--- a/lib/src/test/kotlin/org/kisu/units/chemistry/MolarEnergyTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/chemistry/MolarEnergyTest.kt
@@ -8,6 +8,7 @@ import io.kotest.property.checkAll
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
 import org.kisu.units.builders.joulePerMole
+import org.kisu.units.chemistry.MolarEnergy.Companion.JoulePerMole
 
 class MolarEnergyTest : StringSpec({
     "creates a MolarEnergy" {

--- a/lib/src/test/kotlin/org/kisu/units/chemistry/MolarHeatCapacityTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/chemistry/MolarHeatCapacityTest.kt
@@ -8,6 +8,7 @@ import io.kotest.property.checkAll
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
 import org.kisu.units.builders.joulePerKelvinMole
+import org.kisu.units.chemistry.MolarHeatCapacity.Companion.JoulePerKelvinMole
 
 class MolarHeatCapacityTest : StringSpec({
     "creates a MolarHeatCapacity" {

--- a/lib/src/test/kotlin/org/kisu/units/chemistry/MolarMassTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/chemistry/MolarMassTest.kt
@@ -8,6 +8,7 @@ import io.kotest.property.checkAll
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
 import org.kisu.units.builders.gramsPerMole
+import org.kisu.units.chemistry.MolarMass.Companion.KilogramPerMole
 
 class MolarMassTest : StringSpec({
     "creates a MolarMass" {

--- a/lib/src/test/kotlin/org/kisu/units/chemistry/MolarVolumeTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/chemistry/MolarVolumeTest.kt
@@ -8,6 +8,7 @@ import io.kotest.property.checkAll
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
 import org.kisu.units.builders.cubicMetrePerMole
+import org.kisu.units.chemistry.MolarVolume.Companion.CubicMetrePerMole
 
 class MolarVolumeTest : StringSpec({
     "creates a MolarEnergy" {

--- a/lib/src/test/kotlin/org/kisu/units/chemistry/MolarityTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/chemistry/MolarityTest.kt
@@ -8,6 +8,7 @@ import io.kotest.property.checkAll
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
 import org.kisu.units.builders.molePerCubicMetre
+import org.kisu.units.chemistry.Molarity.Companion.MolePerCubicMetre
 
 class MolarityTest : StringSpec({
     "creates a Molarity" {

--- a/lib/src/test/kotlin/org/kisu/units/photometric/EfficacyTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/photometric/EfficacyTest.kt
@@ -8,6 +8,7 @@ import io.kotest.property.checkAll
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
 import org.kisu.units.builders.lumensPerWatt
+import org.kisu.units.photometric.Efficacy.Companion.LumenPerWatt
 
 class EfficacyTest : StringSpec({
     "creates an Efficacy" {

--- a/lib/src/test/kotlin/org/kisu/units/photometric/ExposureTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/photometric/ExposureTest.kt
@@ -8,6 +8,7 @@ import io.kotest.property.checkAll
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
 import org.kisu.units.builders.luxSecond
+import org.kisu.units.photometric.Exposure.Companion.LuxSecond
 
 class ExposureTest : StringSpec({
     "creates an Exposure" {

--- a/lib/src/test/kotlin/org/kisu/units/photometric/LuminanceTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/photometric/LuminanceTest.kt
@@ -8,6 +8,7 @@ import io.kotest.property.checkAll
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
 import org.kisu.units.builders.candelasPerSquareMetre
+import org.kisu.units.photometric.Luminance.Companion.CandelaPerSquareMetre
 
 class LuminanceTest : StringSpec({
     "creates a Luminance" {

--- a/lib/src/test/kotlin/org/kisu/units/photometric/LuminousEnergyTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/photometric/LuminousEnergyTest.kt
@@ -8,6 +8,7 @@ import io.kotest.property.checkAll
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
 import org.kisu.units.builders.lumensSecond
+import org.kisu.units.photometric.LuminousEnergy.Companion.LumenSecond
 
 class LuminousEnergyTest : StringSpec({
     "creates a LuminousEnergy" {

--- a/lib/src/test/kotlin/org/kisu/units/thermodynamics/HeatCapacityTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/thermodynamics/HeatCapacityTest.kt
@@ -8,6 +8,7 @@ import io.kotest.property.checkAll
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
 import org.kisu.units.builders.joulesPerKelvin
+import org.kisu.units.thermodynamics.HeatCapacity.Companion.JoulePerKelvin
 
 class HeatCapacityTest : StringSpec({
     "creates a HeatCapacity" {

--- a/lib/src/test/kotlin/org/kisu/units/thermodynamics/SpecificHeatCapacityTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/thermodynamics/SpecificHeatCapacityTest.kt
@@ -8,6 +8,7 @@ import io.kotest.property.checkAll
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
 import org.kisu.units.builders.joulesPerKilogramKelvin
+import org.kisu.units.thermodynamics.SpecificHeatCapacity.Companion.JoulePerKilogramKelvin
 
 class SpecificHeatCapacityTest : StringSpec({
     "creates a SpecificHeatCapacity" {

--- a/lib/src/test/kotlin/org/kisu/units/thermodynamics/TemperatureGradientTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/thermodynamics/TemperatureGradientTest.kt
@@ -8,6 +8,7 @@ import io.kotest.property.checkAll
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
 import org.kisu.units.builders.kelvinsPerMetre
+import org.kisu.units.thermodynamics.TemperatureGradient.Companion.KelvinPerMetre
 
 class TemperatureGradientTest : StringSpec({
     "creates a TemperatureGradient" {

--- a/lib/src/test/kotlin/org/kisu/units/thermodynamics/ThermalConductivityTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/thermodynamics/ThermalConductivityTest.kt
@@ -8,6 +8,7 @@ import io.kotest.property.checkAll
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
 import org.kisu.units.builders.wattsPerMetreKelvin
+import org.kisu.units.thermodynamics.ThermalConductivity.Companion.WattPerMetreKelvin
 
 class ThermalConductivityTest : StringSpec({
     "creates a ThermalConductivity" {

--- a/lib/src/test/kotlin/org/kisu/units/thermodynamics/ThermalResistanceTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/thermodynamics/ThermalResistanceTest.kt
@@ -8,6 +8,7 @@ import io.kotest.property.checkAll
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
 import org.kisu.units.builders.kelvinsPerWatt
+import org.kisu.units.thermodynamics.ThermalResistance.Companion.KelvinPerWatt
 
 class ThermalResistanceTest : StringSpec({
     "creates a ThermalResistance" {


### PR DESCRIPTION
Closes #92 
  
## 🐞 Problem to Solve

This PR refactors the measurement unit definitions by introducing **nested typealiases** inside their respective classes. The example shown is `SpecificHeatCapacity`, where the SI unit **Joule per kilogram kelvin (J/(kg·K))** is now encapsulated with a nested typealias `JoulePerKilogramKelvin`.

## 💡 Solution

- Added nested typealiases to encapsulate derived units in their respective classes.
- Updated constructors and factory methods to use the nested typealiases.
- Enhanced KDoc for both the typealias and factory method to explain:
  - Physical meaning
  - Usage examples
  - Internal implementation
- Removed some boilerplate when constructing derived units using metric prefixes.
---
  
  ✅ **Checklist**

- [X] The PR includes a clear and descriptive title
- [X] Related issue(s) are linked in the PR body
- [X] The solution is explained thoroughly
- [X] Tests or proofs are included

