### PR TITLE
[KISU-94] Bumps Kotlin to 2.2.20

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,7 +4,7 @@ pluginManagement {
         mavenCentral()
     }
     plugins {
-        id("org.jetbrains.kotlin.jvm") version "2.2.10"
+        id("org.jetbrains.kotlin.jvm") version "2.2.20"
     }
 }
 


### PR DESCRIPTION
Closes #94 
  
## 🐞 Problem to Solve

Bumps Kotlin to 2.2.20

## 💡 Solution

Bumps Kotlin to 2.2.20

---
  
  ✅ **Checklist**

- [ ] The PR includes a clear and descriptive title
- [ ] Related issue(s) are linked in the PR body
- [ ] The solution is explained thoroughly
- [ ] Tests or proofs are included

