### PR TITLE
[KISU-83] Final touches to testing

### DIFF
--- a/lib/src/main/kotlin/org/kisu/units/builders/MetricUnitBuilder.kt
+++ b/lib/src/main/kotlin/org/kisu/units/builders/MetricUnitBuilder.kt
@@ -295,7 +295,7 @@ val MetricUnitBuilder.cubicMetresPerKilogram: SpecificVolume
  * val molarVolume = 1.milli.cubicMetrePerMole // 0.001 m³/mol
  * ```
  */
-val MetricUnitBuilder.cubicMetrePerMole: MolarVolume
+val MetricUnitBuilder.cubicMetresPerMole: MolarVolume
     get() = MolarVolume(magnitude, metric)
 
 /**
@@ -306,7 +306,7 @@ val MetricUnitBuilder.cubicMetrePerMole: MolarVolume
  * val catalyticEfficiency = 1.micro.cubicMetrePerMoleSecond // 1 * 10^-6 m³/(mol·s)
  * ```
  */
-val MetricUnitBuilder.cubicMetrePerMoleSecond: CatalyticEfficiency
+val MetricUnitBuilder.cubicMetresPerMoleSecond: CatalyticEfficiency
     get() = CatalyticEfficiency(magnitude, metric)
 
 /**
@@ -532,7 +532,7 @@ val MetricUnitBuilder.joulesPerKelvin: HeatCapacity
  * val molarHeatCapacity = 1.joulePerKelvinMole // 1 J/(K·mol)
  * ```
  */
-val MetricUnitBuilder.joulePerKelvinMole: MolarHeatCapacity
+val MetricUnitBuilder.joulesPerKelvinMole: MolarHeatCapacity
     get() = MolarHeatCapacity(magnitude, metric)
 
 /**
@@ -565,7 +565,7 @@ val MetricUnitBuilder.joulesPerKilogramKelvin: SpecificHeatCapacity
  * val molarEnergy = 1.kilo.joulePerMole // 1000 J/mol
  * ```
  */
-val MetricUnitBuilder.joulePerMole: MolarEnergy
+val MetricUnitBuilder.joulesPerMole: MolarEnergy
     get() = MolarEnergy(magnitude, metric)
 
 /**
@@ -591,14 +591,14 @@ val MetricUnitBuilder.joulesPerSquareMetreSecond: EnergyFluxDensity
     get() = EnergyFluxDensity(magnitude, metric)
 
 /**
- * Creates a [MagneticDipoleMoment] measure by applying the metric prefix scale to the magnitude.
+ * Creates an [MagneticDipoleMoment] measure by applying the metric prefix scale to the magnitude.
  *
  * Example usage:
  * ```
- * val dipoleMoment = 1.kilo.joulePerTesla // 1000 J/T
+ * val energyFlux = 1.kilo.joulesPerTesla // 1000 J/T
  * ```
  */
-val MetricUnitBuilder.joulePerTesla: MagneticDipoleMoment
+val MetricUnitBuilder.joulesPerTesla: MagneticDipoleMoment
     get() = MagneticDipoleMoment(magnitude, metric)
 
 /**
@@ -816,6 +816,16 @@ val MetricUnitBuilder.metresPerSecondSquared: Acceleration
 val MetricUnitBuilder.metres: Length get() = Length(magnitude, metric)
 
 /**
+ * Creates an [Amount] measure by applying the metric prefix scale to the magnitude.
+ *
+ * Example usage:
+ * ```
+ * val amount = 3.milli.moles // 3 * 10^-3 moles
+ * ```
+ */
+val MetricUnitBuilder.moles: Amount get() = Amount(magnitude, metric)
+
+/**
  * Creates a [Molarity] measure by applying the metric prefix scale to the magnitude.
  *
  * Example usage:
@@ -823,7 +833,7 @@ val MetricUnitBuilder.metres: Length get() = Length(magnitude, metric)
  * val molarity = 1.molePerCubicMetre // 1 mol/m³
  * ```
  */
-val MetricUnitBuilder.molePerCubicMetre: Molarity
+val MetricUnitBuilder.molesPerCubicMetre: Molarity
     get() = Molarity(magnitude, metric)
 
 /**
@@ -834,18 +844,8 @@ val MetricUnitBuilder.molePerCubicMetre: Molarity
  * val molality = 1.molPerKilogram // 1 mol/kg
  * ```
  */
-val MetricUnitBuilder.molPerKilogram: Molality
+val MetricUnitBuilder.molesPerKilogram: Molality
     get() = Molality(magnitude, metric)
-
-/**
- * Creates an [Amount] measure by applying the metric prefix scale to the magnitude.
- *
- * Example usage:
- * ```
- * val amount = 3.milli.moles // 3 * 10^-3 moles
- * ```
- */
-val MetricUnitBuilder.moles: Amount get() = Amount(magnitude, metric)
 
 /**
  * Creates an [AngularMomentum] measure by applying the metric prefix scale to the magnitude.

--- a/lib/src/main/kotlin/org/kisu/units/builders/MetricUnitBuilder.kt
+++ b/lib/src/main/kotlin/org/kisu/units/builders/MetricUnitBuilder.kt
@@ -356,17 +356,6 @@ val MetricUnitBuilder.farads: Capacitance get() = Capacitance(magnitude, metric)
  *
  * Example usage:
  * ```
- * val yank = 1.kilo.gramMetre // 1 kg·m/s³
- * ```
- */
-val MetricUnitBuilder.gramMetre: Yank
-    get() = Yank(magnitude, metric)
-
-/**
- * Creates a [Yank] measure by applying the metric prefix scale to the magnitude.
- *
- * Example usage:
- * ```
  * val yank = 1.kilo.gramMetreSecondThird // 1 kg·m/s³
  * ```
  */
@@ -383,16 +372,6 @@ val MetricUnitBuilder.gramsMetreSecondCubed: Yank
  */
 val MetricUnitBuilder.gramsPerCubicMetre: Density
     get() = Density(magnitude, metric)
-
-/**
- * Creates a [MolarMass] measure by applying the metric prefix scale to the magnitude.
- *
- * Example usage:
- * ```
- * val temp = 2.kilo.kelvins // 2 * 10^3 kelvins
- * ```
- */
-val MetricUnitBuilder.gramsPerMole: MolarMass get() = MolarMass(magnitude, metric)
 
 /**
  * Creates a [LinearMassDensity] measure by applying the metric prefix scale to the magnitude.
@@ -413,8 +392,7 @@ val MetricUnitBuilder.gramsPerMetre: LinearMassDensity
  * val molarMass = 1.kilo.gramPerMole // 1 kg/mol
  * ```
  */
-val MetricUnitBuilder.gramPerMole: MolarMass
-    get() = MolarMass(magnitude, metric)
+val MetricUnitBuilder.gramsPerMole: MolarMass get() = MolarMass(magnitude, metric)
 
 /**
  * Creates a [MassFlowRate] measure by applying the metric prefix scale to the magnitude.
@@ -1296,7 +1274,7 @@ val MetricUnitBuilder.wattsPerSteradianCubicMetre: SpectralRadiance
  * val spectralIntensity = 1.wattPerSteradianMetre // 1 W/(sr·m)
  * ```
  */
-val MetricUnitBuilder.wattPerSteradianMetre: SpectralIntensity
+val MetricUnitBuilder.wattsPerSteradianMetre: SpectralIntensity
     get() = SpectralIntensity(magnitude, metric)
 
 /**

--- a/lib/src/main/kotlin/org/kisu/units/builders/NumberExtensions.kt
+++ b/lib/src/main/kotlin/org/kisu/units/builders/NumberExtensions.kt
@@ -772,7 +772,7 @@ val Number.wattsPerSteradianCubicMetre: SpectralRadiance get() = SpectralRadianc
  * Creates a [SpectralIntensity] from this [Number] representing a spectralntensity in watt per steradian metre,
  * the SI unit for spectralntensity.
  */
-val Number.wattPerSteradianMetre: SpectralIntensity get() = SpectralIntensity(bigDecimal)
+val Number.wattsPerSteradianMetre: SpectralIntensity get() = SpectralIntensity(bigDecimal)
 
 /**
  * Creates a [Radiance] from this [Number] representing a radiance in watt per steradian square metre,

--- a/lib/src/main/kotlin/org/kisu/units/builders/NumberExtensions.kt
+++ b/lib/src/main/kotlin/org/kisu/units/builders/NumberExtensions.kt
@@ -211,6 +211,12 @@ val Number.coulombsPerSquareMetre: ElectricDisplacementField get() = ElectricDis
 val Number.coulombs: ElectricCharge get() = ElectricCharge(bigDecimal)
 
 /**
+ * Creates a [Volume] from this [Number] representing a volume in cubic metres,
+ * the SI unit for volume.
+ */
+val Number.cubicMetres: Volume get() = Volume(bigDecimal)
+
+/**
  * Creates a [SpecificVolume] from this [Number] representing a specific volume in cubic metre per kilogram,
  * the SI unit for specific volume.
  */
@@ -220,25 +226,19 @@ val Number.cubicMetresPerKilogram: SpecificVolume get() = SpecificVolume(bigDeci
  * Creates a [MolarVolume] from this [Number] representing a molar volume in cubic metre per mole,
  * the SI unit for molar volume.
  */
-val Number.cubicMetrePerMole: MolarVolume get() = MolarVolume(bigDecimal)
+val Number.cubicMetresPerMole: MolarVolume get() = MolarVolume(bigDecimal)
 
 /**
  * Creates a [CatalyticEfficiency] from this [Number] representing a catalytic efficiency in cubic metre per mole
  * second, the SI unit for catalytic efficiency.
  */
-val Number.cubicMetrePerMoleSecond: CatalyticEfficiency get() = CatalyticEfficiency(bigDecimal)
+val Number.cubicMetresPerMoleSecond: CatalyticEfficiency get() = CatalyticEfficiency(bigDecimal)
 
 /**
  * Creates a [VolumetricFlow] from this [Number] representing a volumetric flow in cubic metre per second,
  * the SI unit for volumetric flow.
  */
 val Number.cubicMetresPerSecond: VolumetricFlow get() = VolumetricFlow(bigDecimal)
-
-/**
- * Creates a [Volume] from this [Number] representing a volume in cubic metres,
- * the SI unit for volume.
- */
-val Number.cubicMetres: Volume get() = Volume(bigDecimal)
 
 /**
  * Creates a [Permittivity] from this [Number] representing a permittivity in farad per metre,
@@ -251,12 +251,6 @@ val Number.faradsPerMetre: Permittivity get() = Permittivity(bigDecimal)
  * the SI unit for capacitance.
  */
 val Number.farads: Capacitance get() = Capacitance(bigDecimal)
-
-/**
- * Creates a [Yank] from this [Number] representing a yank in gram metre,
- * the SI unit for yank.
- */
-val Number.gramMetre: Yank get() = Yank(bigDecimal)
 
 /**
  * Creates a [Yank] from this [Number] representing a yank in gram metre second third,
@@ -358,7 +352,7 @@ val Number.joulesPerKelvin: HeatCapacity get() = HeatCapacity(bigDecimal)
  * Creates a [MolarHeatCapacity] from this [Number] representing a molar heat capacity in joule per kelvin mole,
  * the SI unit for molar heat capacity.
  */
-val Number.joulePerKelvinMole: MolarHeatCapacity get() = MolarHeatCapacity(bigDecimal)
+val Number.joulesPerKelvinMole: MolarHeatCapacity get() = MolarHeatCapacity(bigDecimal)
 
 /**
  * Creates a [SpecificEnergy] from this [Number] representing a specific energy in joule per kilogram,
@@ -376,7 +370,7 @@ val Number.joulesPerKilogramKelvin: SpecificHeatCapacity get() = SpecificHeatCap
  * Creates a [MolarEnergy] from this [Number] representing a molar energy in joule per mole,
  * the SI unit for molar energy.
  */
-val Number.joulePerMole: MolarEnergy get() = MolarEnergy(bigDecimal)
+val Number.joulesPerMole: MolarEnergy get() = MolarEnergy(bigDecimal)
 
 /**
  * Creates a [RadiantExposure] from this [Number] representing a radiant exposure in joule per square metre,
@@ -394,7 +388,7 @@ val Number.joulesPerSquareMetreSecond: EnergyFluxDensity get() = EnergyFluxDensi
  * Creates a [MagneticDipoleMoment] from this [Number] representing a magnetic dipole moment in joule per tesla,
  * the SI unit for magnetic dipole moment.
  */
-val Number.joulePerTesla: MagneticDipoleMoment get() = MagneticDipoleMoment(bigDecimal)
+val Number.joulesPerTesla: MagneticDipoleMoment get() = MagneticDipoleMoment(bigDecimal)
 
 /**
  * Creates a [Energy] from this [Number] representing an energy in joules,
@@ -520,7 +514,7 @@ val Number.metres: Length get() = Length(bigDecimal)
  * Creates a [Molarity] from this [Number] representing a molarity in mole per cubic metre,
  * the SI unit for molarity.
  */
-val Number.molePerCubicMetre: Molarity get() = Molarity(bigDecimal)
+val Number.molesPerCubicMetre: Molarity get() = Molarity(bigDecimal)
 
 /**
  * Creates a [Amount] from this [Number] representing an amount in moles,
@@ -532,7 +526,7 @@ val Number.moles: Amount get() = Amount(bigDecimal)
  * Creates a [Molality] from this [Number] representing a molality in mol per kilogram,
  * the SI unit for molality.
  */
-val Number.molPerKilogram: Molality get() = Molality(bigDecimal)
+val Number.molesPerKilogram: Molality get() = Molality(bigDecimal)
 
 /**
  * Creates a [AngularMomentum] from this [Number] representing an angular momentum in newton meter second,

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/Molality.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/Molality.kt
@@ -13,7 +13,7 @@ import java.math.BigDecimal
  * Molality quantifies the **amount of substance of solute per unit mass of solvent**.
  * Unlike molarity, it does not depend on volume (and therefore is unaffected by temperature
  * or pressure changes), making it particularly useful in thermodynamic calculations.
- * Its SI unit is the **mole per kilogram (mol/kg)**, represented here by [MolPerKilogram].
+ * Its SI unit is the **mole per kilogram (mol/kg)**, represented here by [MolePerKilogram].
  *
  * Example usages include:
  * - Expressing the concentration of a solute in a solution
@@ -22,15 +22,15 @@ import java.math.BigDecimal
  *
  * The magnitude is stored as a [BigDecimal] to ensure high precision.
  * Instances of [Molality] are immutable, and the [expression] parameter ties
- * the measurement to its unit representation ([MolPerKilogram]).
+ * the measurement to its unit representation ([MolePerKilogram]).
  *
  * @property magnitude The numeric value of the molality.
- * @property expression The unit expression of the molality, always [MolPerKilogram].
+ * @property expression The unit expression of the molality, always [MolePerKilogram].
  */
 class Molality(
     magnitude: BigDecimal,
-    expression: MolPerKilogram
-) : Measure<Molality.MolPerKilogram, Molality>(magnitude, expression, ::Molality) {
+    expression: MolePerKilogram
+) : Measure<Molality.MolePerKilogram, Molality>(magnitude, expression, ::Molality) {
 
     internal constructor(magnitude: BigDecimal, prefix: Metric = Metric.BASE) :
         this(magnitude, MolPerKilogram(prefix))
@@ -48,7 +48,7 @@ class Molality(
      *
      * @see Molality for the physical quantity represented by this unit.
      */
-    typealias MolPerKilogram = Quotient<Mole, Kilogram>
+    typealias MolePerKilogram = Quotient<Mole, Kilogram>
 
     companion object {
         /**
@@ -67,7 +67,7 @@ class Molality(
          * @return A [Quotient] representing mol/kg.
          */
         @Suppress("FunctionNaming")
-        internal fun MolPerKilogram(prefix: Metric = Metric.BASE): Quotient<Mole, Kilogram> =
+        internal fun MolPerKilogram(prefix: Metric = Metric.BASE): MolePerKilogram =
             Quotient(Mole(prefix), Kilogram())
     }
 }

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/MolarConductivity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/MolarConductivity.kt
@@ -84,7 +84,7 @@ class MolarConductivity(
         @Suppress("FunctionNaming")
         internal fun SiemensSquareMetrePerMole(
             prefix: Metric = Metric.BASE
-        ): Quotient<Product<Siemens, SquareMetre>, Mole> =
+        ): SiemensSquareMetrePerMole =
             Quotient(
                 Product(Siemens(prefix), SquareMetre()),
                 Mole()

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/MolarEnergy.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/MolarEnergy.kt
@@ -68,7 +68,7 @@ class MolarEnergy(
          * @return A [Quotient] representing J/mol.
          */
         @Suppress("FunctionNaming")
-        internal fun JoulePerMole(prefix: Metric = Metric.BASE): Quotient<Joule, Mole> =
+        internal fun JoulePerMole(prefix: Metric = Metric.BASE): JoulePerMole =
             Quotient(Joule(prefix), Mole())
     }
 }

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/MolarHeatCapacity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/MolarHeatCapacity.kt
@@ -76,7 +76,7 @@ class MolarHeatCapacity(
          * @return A [Quotient] representing J/(K·mol).
          */
         @Suppress("FunctionNaming")
-        internal fun JoulePerKelvinMole(prefix: Metric = Metric.BASE): Quotient<Joule, Product<Kelvin, Mole>> =
+        internal fun JoulePerKelvinMole(prefix: Metric = Metric.BASE): JoulePerKelvinMole =
             Quotient(
                 Joule(prefix),
                 Product(Kelvin(), Mole())

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/MolarMass.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/MolarMass.kt
@@ -65,7 +65,7 @@ class MolarMass(
          * @return A [Quotient] representing kg/mol.
          */
         @Suppress("FunctionNaming")
-        internal fun KilogramPerMole(prefix: Metric = Metric.BASE): Quotient<Kilogram, Mole> =
+        internal fun KilogramPerMole(prefix: Metric = Metric.BASE): KilogramPerMole =
             Quotient(Kilogram(prefix), Mole())
     }
 }

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/MolarVolume.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/MolarVolume.kt
@@ -66,7 +66,7 @@ class MolarVolume(
          * @return A [Quotient] representing m³/mol.
          */
         @Suppress("FunctionNaming")
-        internal fun CubicMetrePerMole(prefix: Metric = Metric.BASE): Quotient<CubicMetre, Mole> =
+        internal fun CubicMetrePerMole(prefix: Metric = Metric.BASE): CubicMetrePerMole =
             Quotient(CubicMetre(prefix), Mole())
     }
 }

--- a/lib/src/main/kotlin/org/kisu/units/chemistry/Molarity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/chemistry/Molarity.kt
@@ -66,7 +66,7 @@ class Molarity(
          * @return A [Quotient] representing mol/m³.
          */
         @Suppress("FunctionNaming")
-        internal fun MolePerCubicMetre(prefix: Metric = Metric.BASE): Quotient<Mole, CubicMetre> =
+        internal fun MolePerCubicMetre(prefix: Metric = Metric.BASE): MolePerCubicMetre =
             Quotient(Mole(prefix), CubicMetre())
     }
 }

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/FrequencyDrift.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/FrequencyDrift.kt
@@ -65,7 +65,7 @@ class FrequencyDrift internal constructor(
          * @return A [Quotient] representing Hz/s.
          */
         @Suppress("FunctionNaming")
-        internal fun HertzPerSecond(prefix: Metric = Metric.BASE): Quotient<Hertz, Second> =
+        internal fun HertzPerSecond(prefix: Metric = Metric.BASE): HertzPerSecond =
             Quotient(Hertz(prefix), Second())
     }
 }

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/VolumetricFlow.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/VolumetricFlow.kt
@@ -64,7 +64,7 @@ class VolumetricFlow internal constructor(
          * @return A [Quotient] representing m³/s.
          */
         @Suppress("FunctionNaming")
-        internal fun CubicMetrePerSecond(prefix: Metric = Metric.BASE): Quotient<CubicMetre, Second> =
+        internal fun CubicMetrePerSecond(prefix: Metric = Metric.BASE): CubicMetrePerSecond =
             Quotient(CubicMetre(prefix), Second())
     }
 }

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/Yank.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/Yank.kt
@@ -89,8 +89,7 @@ class Yank internal constructor(
          * @return A [Quotient] representing kg·m/s³.
          */
         @Suppress("FunctionNaming")
-        internal fun KilogramMetrePerSecondCubed(prefix: Metric = Metric.BASE):
-            Quotient<Product<Kilogram, Metre>, SecondCubed> =
+        internal fun KilogramMetrePerSecondCubed(prefix: Metric = Metric.BASE): KilogramMetrePerSecondCubed =
             Quotient(
                 Product(Kilogram(prefix), Metre()),
                 SecondCubed()

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Acceleration.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Acceleration.kt
@@ -64,7 +64,7 @@ class Acceleration(
          * @return A [Quotient] representing rad/s².
          */
         @Suppress("FunctionNaming")
-        internal fun RadianPerSecondSquared(prefix: Metric = Metric.BASE): Quotient<Radian, SecondSquared> =
+        internal fun RadianPerSecondSquared(prefix: Metric = Metric.BASE): RadianPerSecondSquared =
             Quotient(Radian(prefix), SecondSquared())
     }
 }

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Crackle.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Crackle.kt
@@ -66,7 +66,7 @@ class Crackle internal constructor(
          * @return A [Quotient] representing rad/s⁵.
          */
         @Suppress("FunctionNaming")
-        internal fun RadianPerSecondFifth(prefix: Metric = Metric.BASE): Quotient<Radian, SecondFifth> =
+        internal fun RadianPerSecondFifth(prefix: Metric = Metric.BASE): RadianPerSecondFifth =
             Quotient(Radian(prefix), SecondFifth())
     }
 }

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Jerk.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Jerk.kt
@@ -65,7 +65,7 @@ class Jerk(
          * @return A [Quotient] representing rad/s³.
          */
         @Suppress("FunctionNaming")
-        internal fun RadianPerSecondCubed(prefix: Metric = Metric.BASE): Quotient<Radian, SecondCubed> =
+        internal fun RadianPerSecondCubed(prefix: Metric = Metric.BASE): RadianPerSecondCubed =
             Quotient(Radian(prefix), SecondCubed())
     }
 }

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Pop.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Pop.kt
@@ -66,7 +66,7 @@ class Pop internal constructor(
          * @return A [Quotient] representing rad/s⁶.
          */
         @Suppress("FunctionNaming")
-        internal fun RadianPerSecondSixth(prefix: Metric = Metric.BASE): Quotient<Radian, SecondSixth> =
+        internal fun RadianPerSecondSixth(prefix: Metric = Metric.BASE): RadianPerSecondSixth =
             Quotient(Radian(prefix), SecondSixth())
     }
 }

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Snap.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Snap.kt
@@ -65,7 +65,7 @@ class Snap(
          * @return A [Quotient] representing rad/s⁴.
          */
         @Suppress("FunctionNaming")
-        internal fun RadianPerSecondFourth(prefix: Metric = Metric.BASE): Quotient<Radian, SecondFourth> =
+        internal fun RadianPerSecondFourth(prefix: Metric = Metric.BASE): RadianPerSecondFourth =
             Quotient(Radian(prefix), SecondFourth())
     }
 }

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Velocity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/angular/Velocity.kt
@@ -64,7 +64,7 @@ class Velocity(
          * @return A [Quotient] representing rad/s.
          */
         @Suppress("FunctionNaming")
-        internal fun RadianPerSecond(prefix: Metric = Metric.BASE): Quotient<Radian, Second> =
+        internal fun RadianPerSecond(prefix: Metric = Metric.BASE): RadianPerSecond =
             Quotient(Radian(prefix), Second())
     }
 }

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Acceleration.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Acceleration.kt
@@ -64,7 +64,7 @@ class Acceleration(
          * @return A [Quotient] representing m/s².
          */
         @Suppress("FunctionNaming")
-        internal fun MetrePerSecondSquared(prefix: Metric = Metric.BASE): Quotient<Metre, SecondSquared> =
+        internal fun MetrePerSecondSquared(prefix: Metric = Metric.BASE): MetrePerSecondSquared =
             Quotient(Metre(prefix), SecondSquared())
     }
 }

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Crackle.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Crackle.kt
@@ -65,7 +65,7 @@ class Crackle internal constructor(
          * @return A [Quotient] representing m/s⁵.
          */
         @Suppress("FunctionNaming")
-        internal fun MetrePerSecondFifth(prefix: Metric = Metric.BASE): Quotient<Metre, SecondFifth> =
+        internal fun MetrePerSecondFifth(prefix: Metric = Metric.BASE): MetrePerSecondFifth =
             Quotient(Metre(prefix), SecondFifth())
     }
 }

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Jerk.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Jerk.kt
@@ -65,7 +65,7 @@ class Jerk(
          * @return A [Quotient] representing m/s³.
          */
         @Suppress("FunctionNaming")
-        internal fun MetrePerSecondCubed(prefix: Metric = Metric.BASE): Quotient<Metre, SecondCubed> =
+        internal fun MetrePerSecondCubed(prefix: Metric = Metric.BASE): MetrePerSecondCubed =
             Quotient(Metre(prefix), SecondCubed())
     }
 }

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Pop.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Pop.kt
@@ -64,7 +64,7 @@ class Pop internal constructor(
          * @return A [Quotient] representing m/s⁶.
          */
         @Suppress("FunctionNaming")
-        internal fun MetrePerSecondSixth(prefix: Metric = Metric.BASE): Quotient<Metre, SecondSixth> =
+        internal fun MetrePerSecondSixth(prefix: Metric = Metric.BASE): MetrePerSecondSixth =
             Quotient(Metre(prefix), SecondSixth())
     }
 }

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Snap.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Snap.kt
@@ -65,7 +65,7 @@ class Snap(
          * @return A [Quotient] representing m/s⁴.
          */
         @Suppress("FunctionNaming")
-        internal fun MetrePerSecondFourth(prefix: Metric = Metric.BASE): Quotient<Metre, SecondFourth> =
+        internal fun MetrePerSecondFourth(prefix: Metric = Metric.BASE): MetrePerSecondFourth =
             Quotient(Metre(prefix), SecondFourth())
     }
 }

--- a/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Speed.kt
+++ b/lib/src/main/kotlin/org/kisu/units/kinematics/linear/Speed.kt
@@ -60,7 +60,7 @@ class Speed(
          * @return A [Quotient] representing m/s.
          */
         @Suppress("FunctionNaming")
-        internal fun MetrePerSecond(prefix: Metric = Metric.BASE): Quotient<Metre, Second> =
+        internal fun MetrePerSecond(prefix: Metric = Metric.BASE): MetrePerSecond =
             Quotient(Metre(prefix), Second())
     }
 }

--- a/lib/src/main/kotlin/org/kisu/units/photometric/Efficacy.kt
+++ b/lib/src/main/kotlin/org/kisu/units/photometric/Efficacy.kt
@@ -61,7 +61,7 @@ class Efficacy(
          * @return A [Quotient] representing lm/W.
          */
         @Suppress("FunctionNaming")
-        internal fun LumenPerWatt(prefix: Metric = Metric.BASE): Quotient<Lumen, Watt> =
+        internal fun LumenPerWatt(prefix: Metric = Metric.BASE): LumenPerWatt =
             Quotient(Lumen(prefix), Watt())
     }
 }

--- a/lib/src/main/kotlin/org/kisu/units/photometric/Exposure.kt
+++ b/lib/src/main/kotlin/org/kisu/units/photometric/Exposure.kt
@@ -64,7 +64,7 @@ class Exposure(
          * @return A [Product] representing lx·s.
          */
         @Suppress("FunctionNaming")
-        internal fun LuxSecond(prefix: Metric = Metric.BASE): Product<Lux, Second> =
+        internal fun LuxSecond(prefix: Metric = Metric.BASE): LuxSecond =
             Product(Lux(prefix), Second())
     }
 }

--- a/lib/src/main/kotlin/org/kisu/units/photometric/Luminance.kt
+++ b/lib/src/main/kotlin/org/kisu/units/photometric/Luminance.kt
@@ -66,7 +66,7 @@ class Luminance(
          * @return A [Quotient] representing cd/m².
          */
         @Suppress("FunctionNaming")
-        internal fun CandelaPerSquareMetre(prefix: Metric = Metric.BASE): Quotient<Candela, SquareMetre> =
+        internal fun CandelaPerSquareMetre(prefix: Metric = Metric.BASE): CandelaPerSquareMetre =
             Quotient(Candela(prefix), SquareMetre())
     }
 }

--- a/lib/src/main/kotlin/org/kisu/units/photometric/LuminousEnergy.kt
+++ b/lib/src/main/kotlin/org/kisu/units/photometric/LuminousEnergy.kt
@@ -64,7 +64,7 @@ class LuminousEnergy(
          * @return A [Product] representing lm·s.
          */
         @Suppress("FunctionNaming")
-        internal fun LumenSecond(prefix: Metric = Metric.BASE): Product<Lumen, Second> =
+        internal fun LumenSecond(prefix: Metric = Metric.BASE): LumenSecond =
             Product(Lumen(prefix), Second())
     }
 }

--- a/lib/src/main/kotlin/org/kisu/units/thermodynamics/HeatCapacity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/thermodynamics/HeatCapacity.kt
@@ -65,7 +65,7 @@ class HeatCapacity(
          * @return A [Quotient] representing J/K.
          */
         @Suppress("FunctionNaming")
-        internal fun JoulePerKelvin(prefix: Metric = Metric.BASE): Quotient<Joule, Kelvin> =
+        internal fun JoulePerKelvin(prefix: Metric = Metric.BASE): JoulePerKelvin =
             Quotient(Joule(prefix), Kelvin())
     }
 }

--- a/lib/src/main/kotlin/org/kisu/units/thermodynamics/SpecificHeatCapacity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/thermodynamics/SpecificHeatCapacity.kt
@@ -76,7 +76,7 @@ class SpecificHeatCapacity(
          * @return A [Quotient] representing J/(kg·K).
          */
         @Suppress("FunctionNaming")
-        internal fun JoulePerKilogramKelvin(prefix: Metric = Metric.BASE): Quotient<Joule, Product<Kilogram, Kelvin>> =
+        internal fun JoulePerKilogramKelvin(prefix: Metric = Metric.BASE): JoulePerKilogramKelvin =
             Quotient(
                 Joule(),
                 Product(Kilogram(prefix), Kelvin())

--- a/lib/src/main/kotlin/org/kisu/units/thermodynamics/TemperatureGradient.kt
+++ b/lib/src/main/kotlin/org/kisu/units/thermodynamics/TemperatureGradient.kt
@@ -69,7 +69,7 @@ class TemperatureGradient(
          * @return A [Quotient] representing K/m.
          */
         @Suppress("FunctionNaming")
-        internal fun KelvinPerMetre(prefix: Metric = Metric.BASE): Quotient<Kelvin, Metre> =
+        internal fun KelvinPerMetre(prefix: Metric = Metric.BASE): KelvinPerMetre =
             Quotient(Kelvin(prefix), Metre())
     }
 }

--- a/lib/src/main/kotlin/org/kisu/units/thermodynamics/ThermalConductivity.kt
+++ b/lib/src/main/kotlin/org/kisu/units/thermodynamics/ThermalConductivity.kt
@@ -75,7 +75,7 @@ class ThermalConductivity(
          * @return A [Quotient] representing W/(m·K).
          */
         @Suppress("FunctionNaming")
-        internal fun WattPerMetreKelvin(prefix: Metric = Metric.BASE): Quotient<Watt, Product<Metre, Kelvin>> =
+        internal fun WattPerMetreKelvin(prefix: Metric = Metric.BASE): WattPerMetreKelvin =
             Quotient(Watt(prefix), Product(Metre(), Kelvin()))
     }
 }

--- a/lib/src/main/kotlin/org/kisu/units/thermodynamics/ThermalResistance.kt
+++ b/lib/src/main/kotlin/org/kisu/units/thermodynamics/ThermalResistance.kt
@@ -67,7 +67,7 @@ class ThermalResistance(
          * @return A [Quotient] representing K/W.
          */
         @Suppress("FunctionNaming")
-        internal fun KelvinPerWatt(prefix: Metric = Metric.BASE): Quotient<Kelvin, Watt> =
+        internal fun KelvinPerWatt(prefix: Metric = Metric.BASE): KelvinPerWatt =
             Quotient(Kelvin(prefix), Watt())
     }
 }

--- a/lib/src/test/kotlin/org/kisu/units/chemistry/CatalyticEfficiencyTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/chemistry/CatalyticEfficiencyTest.kt
@@ -7,13 +7,13 @@ import io.kotest.property.Arb
 import io.kotest.property.checkAll
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
-import org.kisu.units.builders.cubicMetrePerMoleSecond
+import org.kisu.units.builders.cubicMetresPerMoleSecond
 import org.kisu.units.chemistry.CatalyticEfficiency.Companion.CubicMetrePerMoleSecond
 
 class CatalyticEfficiencyTest : StringSpec({
     "creates a CatalyticEfficiency" {
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
-            magnitude.builder().cubicMetrePerMoleSecond.should { (amount, expression, symbol) ->
+            magnitude.builder().cubicMetresPerMoleSecond.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
                 expression shouldBe CubicMetrePerMoleSecond(magnitude.builder().metric)
                 symbol shouldBe CubicMetrePerMoleSecond().toString()
@@ -23,7 +23,7 @@ class CatalyticEfficiencyTest : StringSpec({
 
     "creates a base CatalyticEfficiency" {
         checkAll(Arb.bigDecimal()) { magnitude ->
-            magnitude.cubicMetrePerMoleSecond.should { (amount, expression, symbol) ->
+            magnitude.cubicMetresPerMoleSecond.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
                 expression shouldBe CubicMetrePerMoleSecond()
                 symbol shouldBe CubicMetrePerMoleSecond().toString()

--- a/lib/src/test/kotlin/org/kisu/units/chemistry/MolalityTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/chemistry/MolalityTest.kt
@@ -7,13 +7,13 @@ import io.kotest.property.Arb
 import io.kotest.property.checkAll
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
-import org.kisu.units.builders.molPerKilogram
+import org.kisu.units.builders.molesPerKilogram
 import org.kisu.units.chemistry.Molality.Companion.MolPerKilogram
 
 class MolalityTest : StringSpec({
     "creates a Molality" {
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
-            magnitude.builder().molPerKilogram.should { (amount, expression, symbol) ->
+            magnitude.builder().molesPerKilogram.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
                 expression shouldBe MolPerKilogram(magnitude.builder().metric)
                 symbol shouldBe MolPerKilogram().toString()
@@ -23,7 +23,7 @@ class MolalityTest : StringSpec({
 
     "creates a base Molality" {
         checkAll(Arb.bigDecimal()) { magnitude ->
-            magnitude.molPerKilogram.should { (amount, expression, symbol) ->
+            magnitude.molesPerKilogram.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
                 expression shouldBe MolPerKilogram()
                 symbol shouldBe MolPerKilogram().toString()

--- a/lib/src/test/kotlin/org/kisu/units/chemistry/MolarEnergyTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/chemistry/MolarEnergyTest.kt
@@ -7,13 +7,13 @@ import io.kotest.property.Arb
 import io.kotest.property.checkAll
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
-import org.kisu.units.builders.joulePerMole
+import org.kisu.units.builders.joulesPerMole
 import org.kisu.units.chemistry.MolarEnergy.Companion.JoulePerMole
 
 class MolarEnergyTest : StringSpec({
     "creates a MolarEnergy" {
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
-            magnitude.builder().joulePerMole.should { (amount, expression, symbol) ->
+            magnitude.builder().joulesPerMole.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
                 expression shouldBe JoulePerMole(magnitude.builder().metric)
                 symbol shouldBe JoulePerMole().toString()
@@ -23,7 +23,7 @@ class MolarEnergyTest : StringSpec({
 
     "creates a base MolarEnergy" {
         checkAll(Arb.bigDecimal()) { magnitude ->
-            magnitude.joulePerMole.should { (amount, expression, symbol) ->
+            magnitude.joulesPerMole.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
                 expression shouldBe JoulePerMole()
                 symbol shouldBe JoulePerMole().toString()

--- a/lib/src/test/kotlin/org/kisu/units/chemistry/MolarHeatCapacityTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/chemistry/MolarHeatCapacityTest.kt
@@ -7,13 +7,13 @@ import io.kotest.property.Arb
 import io.kotest.property.checkAll
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
-import org.kisu.units.builders.joulePerKelvinMole
+import org.kisu.units.builders.joulesPerKelvinMole
 import org.kisu.units.chemistry.MolarHeatCapacity.Companion.JoulePerKelvinMole
 
 class MolarHeatCapacityTest : StringSpec({
     "creates a MolarHeatCapacity" {
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
-            magnitude.builder().joulePerKelvinMole.should { (amount, expression, symbol) ->
+            magnitude.builder().joulesPerKelvinMole.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
                 expression shouldBe JoulePerKelvinMole(magnitude.builder().metric)
                 symbol shouldBe JoulePerKelvinMole().toString()
@@ -23,7 +23,7 @@ class MolarHeatCapacityTest : StringSpec({
 
     "creates a base MolarHeatCapacity" {
         checkAll(Arb.bigDecimal()) { magnitude ->
-            magnitude.joulePerKelvinMole.should { (amount, expression, symbol) ->
+            magnitude.joulesPerKelvinMole.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
                 expression shouldBe JoulePerKelvinMole()
                 symbol shouldBe JoulePerKelvinMole().toString()

--- a/lib/src/test/kotlin/org/kisu/units/chemistry/MolarVolumeTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/chemistry/MolarVolumeTest.kt
@@ -7,13 +7,13 @@ import io.kotest.property.Arb
 import io.kotest.property.checkAll
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
-import org.kisu.units.builders.cubicMetrePerMole
+import org.kisu.units.builders.cubicMetresPerMole
 import org.kisu.units.chemistry.MolarVolume.Companion.CubicMetrePerMole
 
 class MolarVolumeTest : StringSpec({
     "creates a MolarEnergy" {
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
-            magnitude.builder().cubicMetrePerMole.should { (amount, expression, symbol) ->
+            magnitude.builder().cubicMetresPerMole.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
                 expression shouldBe CubicMetrePerMole(magnitude.builder().metric)
                 symbol shouldBe CubicMetrePerMole().toString()
@@ -23,7 +23,7 @@ class MolarVolumeTest : StringSpec({
 
     "creates a base MolarEnergy" {
         checkAll(Arb.bigDecimal()) { magnitude ->
-            magnitude.cubicMetrePerMole.should { (amount, expression, symbol) ->
+            magnitude.cubicMetresPerMole.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
                 expression shouldBe CubicMetrePerMole()
                 symbol shouldBe CubicMetrePerMole().toString()

--- a/lib/src/test/kotlin/org/kisu/units/chemistry/MolarityTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/chemistry/MolarityTest.kt
@@ -7,13 +7,13 @@ import io.kotest.property.Arb
 import io.kotest.property.checkAll
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
-import org.kisu.units.builders.molePerCubicMetre
+import org.kisu.units.builders.molesPerCubicMetre
 import org.kisu.units.chemistry.Molarity.Companion.MolePerCubicMetre
 
 class MolarityTest : StringSpec({
     "creates a Molarity" {
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
-            magnitude.builder().molePerCubicMetre.should { (amount, expression, symbol) ->
+            magnitude.builder().molesPerCubicMetre.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
                 expression shouldBe MolePerCubicMetre(magnitude.builder().metric)
                 symbol shouldBe MolePerCubicMetre().toString()
@@ -23,7 +23,7 @@ class MolarityTest : StringSpec({
 
     "creates a base Molarity" {
         checkAll(Arb.bigDecimal()) { magnitude ->
-            magnitude.molePerCubicMetre.should { (amount, expression, symbol) ->
+            magnitude.molesPerCubicMetre.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
                 expression shouldBe MolePerCubicMetre()
                 symbol shouldBe MolePerCubicMetre().toString()

--- a/lib/src/test/kotlin/org/kisu/units/electromagnetic/MagneticDipoleMomentTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/electromagnetic/MagneticDipoleMomentTest.kt
@@ -7,13 +7,13 @@ import io.kotest.property.Arb
 import io.kotest.property.checkAll
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
-import org.kisu.units.builders.joulePerTesla
+import org.kisu.units.builders.joulesPerTesla
 import org.kisu.units.electromagnetic.MagneticDipoleMoment.Companion.JoulePerTesla
 
 class MagneticDipoleMomentTest : StringSpec({
     "creates a MagneticDipoleMoment" {
         checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
-            magnitude.builder().joulePerTesla.should { (amount, expression, symbol) ->
+            magnitude.builder().joulesPerTesla.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
                 expression shouldBe JoulePerTesla(magnitude.builder().metric)
                 symbol shouldBe JoulePerTesla().toString()
@@ -23,7 +23,7 @@ class MagneticDipoleMomentTest : StringSpec({
 
     "creates a base MagneticDipoleMoment" {
         checkAll(Arb.bigDecimal()) { magnitude ->
-            magnitude.joulePerTesla.should { (amount, expression, symbol) ->
+            magnitude.joulesPerTesla.should { (amount, expression, symbol) ->
                 amount shouldBe magnitude
                 expression shouldBe JoulePerTesla()
                 symbol shouldBe JoulePerTesla().toString()

--- a/lib/src/test/kotlin/org/kisu/units/mechanics/SpectralIntensityTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/mechanics/SpectralIntensityTest.kt
@@ -8,7 +8,6 @@ import io.kotest.property.checkAll
 import org.kisu.test.generators.MetricBuilders
 import org.kisu.test.generators.bigDecimal
 import org.kisu.units.builders.wattsPerSteradianMetre
-import org.kisu.units.kinematics.Yank.Companion.KilogramMetrePerSecondCubed
 import org.kisu.units.mechanics.SpectralIntensity.Companion.WattPerSteradianMetre
 
 class SpectralIntensityTest : StringSpec({

--- a/lib/src/test/kotlin/org/kisu/units/mechanics/SpectralIntensityTest.kt
+++ b/lib/src/test/kotlin/org/kisu/units/mechanics/SpectralIntensityTest.kt
@@ -1,0 +1,34 @@
+package org.kisu.units.mechanics
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.checkAll
+import org.kisu.test.generators.MetricBuilders
+import org.kisu.test.generators.bigDecimal
+import org.kisu.units.builders.wattsPerSteradianMetre
+import org.kisu.units.kinematics.Yank.Companion.KilogramMetrePerSecondCubed
+import org.kisu.units.mechanics.SpectralIntensity.Companion.WattPerSteradianMetre
+
+class SpectralIntensityTest : StringSpec({
+    "creates a SpectralIntensity" {
+        checkAll(Arb.bigDecimal(), MetricBuilders.generator) { magnitude, builder ->
+            magnitude.builder().wattsPerSteradianMetre.should { (amount, expression, symbol) ->
+                amount shouldBe magnitude
+                expression shouldBe WattPerSteradianMetre(magnitude.builder().metric)
+                symbol shouldBe WattPerSteradianMetre().toString()
+            }
+        }
+    }
+
+    "creates a base SpectralIntensity" {
+        checkAll(Arb.bigDecimal()) { magnitude ->
+            magnitude.wattsPerSteradianMetre.should { (amount, expression, symbol) ->
+                amount shouldBe magnitude
+                expression shouldBe WattPerSteradianMetre()
+                symbol shouldBe WattPerSteradianMetre().toString()
+            }
+        }
+    }
+})


### PR DESCRIPTION
Closes #83

## 🐞 Problem to Solve

The branch finishes the testing-related cleanup around derived unit builders and extensions. Several builder and number extension names were inconsistent with the unit APIs, some derived units were still returning raw quotient/product types instead of the declared typealiases, and SpectralIntensity was missing direct coverage.

## 💡 Solution

Normalized the affected builder and number extension names so the APIs line up with the unit definitions, removed a few incorrect or redundant accessors, and updated derived unit factories to return their typealiases where possible. The branch also fixes the related tests and adds coverage for `SpectralIntensity`.
