### PR TITLE
KISU-100 Enable CodeRabbit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+early_access: false
+
+reviews:
+  profile: "chill"
+  high_level_summary: true
+  review_status: true
+  review_details: false
+  request_changes_workflow: false
+  auto_review:
+    enabled: true
+    drafts: false
+
+chat:
+  auto_reply: true


### PR DESCRIPTION
Closes #100
  
## 🐞 Problem to Solve

The repository did not have a committed CodeRabbit configuration, so review behavior would depend on default app settings instead of repo-owned settings.

## 💡 Solution

Added a root .coderabbit.yaml file with a minimal configuration for this Kotlin and Gradle repo. It enables automatic review on non-draft PRs, keeps review summaries and status reporting on, disables detailed review output by default, and enables chat auto-replies.

## 🧪 Proof

Verified the PR branch only contains a single file change: .coderabbit.yaml.

---
  
  ✅ **Checklist**

- [x] The PR includes a clear and descriptive title
- [x] Related issue(s) are linked in the PR body
- [x] The solution is explained thoroughly
- [x] Tests or proofs are included